### PR TITLE
test(cli): cover webhook commands

### DIFF
--- a/apps/cli/test/webhook.test.ts
+++ b/apps/cli/test/webhook.test.ts
@@ -1,0 +1,198 @@
+// Set a temporary config directory before importing the command modules so
+// this file never reads or writes a user's real ~/.gnt/credentials.json.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-webhook-test-"));
+const previousConfigDir = process.env.GNT_CONFIG_DIR;
+process.env.GNT_CONFIG_DIR = testConfigDir;
+
+const { saveApiKey } = await import("../src/credentials.js");
+const {
+  createWebhookToken,
+  listWebhookTokens,
+  revokeWebhookToken,
+} = await import("../src/commands/webhook.js");
+
+// Bun loads all test files into one process. Restore the prior value after
+// imports so this file cannot affect another file's module setup.
+if (previousConfigDir === undefined) {
+  delete process.env.GNT_CONFIG_DIR;
+} else {
+  process.env.GNT_CONFIG_DIR = previousConfigDir;
+}
+
+const credentialsPath = join(testConfigDir, "credentials.json");
+
+let originalFetch: typeof fetch;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+
+let logs: string[];
+let errors: string[];
+let exitCalls: number[];
+let fetchCalls: Array<{ input: string; init?: RequestInit }>;
+
+// eslint-disable-next-line no-control-regex -- strips terminal ANSI color sequences before assertions.
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+
+function output() {
+  return logs.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function errorOutput() {
+  return errors.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+// Install a fake fetch: record requests and return a supplied API response.
+function mockFetch(body: unknown, status = 200) {
+  const fetchMock = mock((input: string | URL | Request, init?: RequestInit) => {
+    fetchCalls.push({ input: String(input), init });
+
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+
+  // credentials.ts reads this environment variable at call time.
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  saveApiKey("gnt_live_test_key", "key-id");
+
+  logs = [];
+  errors = [];
+  exitCalls = [];
+  fetchCalls = [];
+
+  // Capture terminal output for assertions.
+  console.log = (...args: unknown[]) => {
+    logs.push(args.join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args.join(" "));
+  };
+
+  // Keep the error-path test from terminating Bun itself.
+  process.exit = ((code?: number | string) => {
+    exitCalls.push(Number(code));
+  }) as unknown as typeof process.exit;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+
+  // Remove this test's fake login credentials.
+  rmSync(credentialsPath, { force: true });
+
+  if (previousConfigDir === undefined) {
+    delete process.env.GNT_CONFIG_DIR;
+  } else {
+    process.env.GNT_CONFIG_DIR = previousConfigDir;
+  }
+});
+
+test("prints a message when there are no webhook tokens", async () => {
+  mockFetch([]);
+
+  await listWebhookTokens();
+
+  expect(output()).toContain(
+    "No webhook tokens yet. Create one with `gnt webhook create`.",
+  );
+});
+
+test("lists aligned webhook tokens with revoked, used, and unused states", async () => {
+  mockFetch([
+    {
+      id: "a",
+      name: "short",
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: null,
+      revoked_at: null,
+    },
+    {
+      id: "much-longer-token-id",
+      name: "a longer token name",
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: "2026-08-02T08:30:00Z",
+      revoked_at: null,
+    },
+    {
+      id: "revoked-id",
+      name: null,
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: null,
+      revoked_at: "2026-08-02T09:00:00Z",
+    },
+  ]);
+
+  await listWebhookTokens();
+
+  // \s+ accepts the variable padding introduced by padEnd column alignment.
+  expect(output()).toMatch(/^a\s+short\s+unused$/m);
+  expect(output()).toMatch(
+    /^much-longer-token-id\s+a longer token name\s+last used 2026-08-02T08:30:00Z$/m,
+  );
+  expect(output()).toMatch(/^revoked-id\s+\(unnamed\)\s+revoked$/m);
+});
+
+test("creates an unnamed webhook token with name set to null", async () => {
+  mockFetch({ ingest_url: "https://api.gntai.dev/v1/ingest/example" });
+
+  await createWebhookToken();
+
+  expect(fetchCalls).toHaveLength(1);
+  expect(fetchCalls[0].input).toContain("/v1/settings/webhook-tokens");
+  expect(fetchCalls[0].init?.method).toBe("POST");
+  expect(fetchCalls[0].init?.body).toBe('{"name":null}');
+});
+
+test("creates a named webhook token and prints its ingest URL", async () => {
+  const ingestUrl = "https://api.gntai.dev/v1/ingest/my-token";
+  mockFetch({ ingest_url: ingestUrl });
+
+  await createWebhookToken("my token");
+
+  expect(fetchCalls[0].init?.body).toBe('{"name":"my token"}');
+  expect(output()).toContain(ingestUrl);
+});
+
+test("revokes the requested webhook token", async () => {
+  mockFetch({});
+
+  await revokeWebhookToken("some-id");
+
+  expect(fetchCalls[0].input).toContain(
+    "/v1/settings/webhook-tokens/some-id/revoke",
+  );
+  expect(fetchCalls[0].init?.method).toBe("POST");
+  expect(output()).toContain("Revoked some-id");
+});
+
+test("prints an error and exits when the API response is not ok", async () => {
+  // Use a JSON body because the mocked process.exit returns to the function.
+  mockFetch({}, 500);
+
+  await createWebhookToken();
+
+  expect(errorOutput()).toContain("Failed to create webhook token (500).");
+  expect(exitCalls).toEqual([1]);
+});

--- a/apps/cli/test/webhook.test.ts
+++ b/apps/cli/test/webhook.test.ts
@@ -90,6 +90,7 @@ beforeEach(() => {
   // Keep the error-path test from terminating Bun itself.
   process.exit = ((code?: number | string) => {
     exitCalls.push(Number(code));
+    throw new Error("test process exit");
   }) as unknown as typeof process.exit;
 });
 
@@ -160,7 +161,7 @@ test("creates an unnamed webhook token with name set to null", async () => {
   await createWebhookToken();
 
   expect(fetchCalls).toHaveLength(1);
-  expect(fetchCalls[0].input).toContain("/v1/settings/webhook-tokens");
+  expect(new URL(fetchCalls[0].input).pathname).toBe("/v1/settings/webhook-tokens");
   expect(fetchCalls[0].init?.method).toBe("POST");
   expect(fetchCalls[0].init?.body).toBe('{"name":null}');
 });
@@ -180,7 +181,7 @@ test("revokes the requested webhook token", async () => {
 
   await revokeWebhookToken("some-id");
 
-  expect(fetchCalls[0].input).toContain(
+  expect(new URL(fetchCalls[0].input).pathname).toBe(
     "/v1/settings/webhook-tokens/some-id/revoke",
   );
   expect(fetchCalls[0].init?.method).toBe("POST");
@@ -188,10 +189,9 @@ test("revokes the requested webhook token", async () => {
 });
 
 test("prints an error and exits when the API response is not ok", async () => {
-  // Use a JSON body because the mocked process.exit returns to the function.
   mockFetch({}, 500);
 
-  await createWebhookToken();
+  await expect(createWebhookToken()).rejects.toThrow("test process exit");
 
   expect(errorOutput()).toContain("Failed to create webhook token (500).");
   expect(exitCalls).toEqual([1]);


### PR DESCRIPTION
## What & why

Adds coverage for `gnt webhook list`, `create`, and `revoke`.

The new tests cover:
- Empty and aligned webhook-token list output, including revoked, used, and unused states.
- Creating unnamed tokens with `{"name":null}` and named tokens with the supplied name.
- Revoking a token with the correct endpoint and confirmation output.
- API failure handling via `console.error` and `process.exit(1)`.

## Test plan

- [x] `bun test webhook.test.ts` — 6 pass, 0 fail
- [x] `bun test` — 757 pass, 1 skip, 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint`

## Before you open this

- [x] Commits are signed off (`git commit -s`).
- [x] Functionally correct: ran the relevant CLI test suite locally.
- [x] No dead code, unused imports, or debug logging.
- [x] The added test follows the existing CLI test setup and fetch-mocking patterns.
- [x] No production or multi-tenant behavior changed; this PR only adds CLI tests.
- [x] Does not touch `apps/cli/src/prebrain/extraction/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for webhook token listing, creation, revocation, output formatting, and API error handling.
  * Improved test isolation with temporary credentials, mocked network requests, captured output, and intercepted process exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->