### PR TITLE
docs: add CHANGELOG.md (Keep a Changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file is the source of truth for release notes going forward. Entries for
+versions published before the public repo existed (`0.1.0` through `0.5.7`) are
+best-effort placeholders — those releases predate recorded changelog history.
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.6.0] - 2026-07-23
+
+This is where public release tracking starts — `gnt-ai/gnt`'s history begins
+with a single squashed commit from the Apache-2.0 relicense/public cut, so
+there's no real incremental history to generate notes from for this one.
+
+`@gnt-ai/cli` was already at 0.6.0 on npm before this repo went public.
+Versions 0.1.0 through 0.5.7 predate the public repo entirely — see
+`npm view @gnt-ai/cli versions` for the raw version list if you want it, but
+there's no changelog for them beyond that.
+
+From here on, every real `@gnt-ai/cli` version bump is auto-tagged and
+auto-noted the moment it publishes to npm, and any public-repo-only activity
+in between gets a weekly batch release (see `batch-release.yml`).
+
+## [0.5.7] - 2026-07-21
+
+Pre-changelog release — see npm/git history.
+
+## [0.5.6] - 2026-07-21
+
+Pre-changelog release — see npm/git history.
+
+## [0.5.4] - 2026-07-21
+
+Pre-changelog release — see npm/git history.
+
+## [0.5.3] - 2026-07-20
+
+Pre-changelog release — see npm/git history.
+
+## [0.5.2] - 2026-07-20
+
+Pre-changelog release — see npm/git history.
+
+## [0.5.1] - 2026-07-20
+
+Pre-changelog release — see npm/git history.
+
+## [0.5.0] - 2026-07-18
+
+Pre-changelog release — see npm/git history.
+
+## [0.4.1] - 2026-07-16
+
+Pre-changelog release — see npm/git history.
+
+## [0.4.0] - 2026-07-15
+
+Pre-changelog release — see npm/git history.
+
+## [0.3.0] - 2026-07-15
+
+Pre-changelog release — see npm/git history.
+
+## [0.1.0] - 2026-07-15
+
+Pre-changelog release — see npm/git history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 This file is the source of truth for release notes going forward. Entries for
-versions published before the public repo existed (`0.1.0` through `0.5.7`) are
-best-effort placeholders — those releases predate recorded changelog history.
+versions published before the public repo existed are best-effort placeholders —
+those releases predate recorded changelog history. Only versions that actually
+exist on npm are listed (`npm view @gnt-ai/cli versions`); there was no `0.2.0`
+or `0.5.5` publish.
 
 ## [Unreleased]
 
 Nothing yet.
 
-## [0.6.0] - 2026-07-23
+## [0.6.0] - 2026-07-27
 
-This is where public release tracking starts — `gnt-ai/gnt`'s history begins
-with a single squashed commit from the Apache-2.0 relicense/public cut, so
-there's no real incremental history to generate notes from for this one.
+### Added
 
-`@gnt-ai/cli` was already at 0.6.0 on npm before this repo went public.
-Versions 0.1.0 through 0.5.7 predate the public repo entirely — see
-`npm view @gnt-ai/cli versions` for the raw version list if you want it, but
-there's no changelog for them beyond that.
-
-From here on, every real `@gnt-ai/cli` version bump is auto-tagged and
-auto-noted the moment it publishes to npm, and any public-repo-only activity
-in between gets a weekly batch release (see `batch-release.yml`).
+- Public tracking for `@gnt-ai/cli` starts here. The package was already at
+  `0.6.0` on npm before `gnt-ai/gnt` went public; the repo history begins with a
+  single squashed commit from the Apache-2.0 relicense/public cut, so there is
+  no real incremental history to generate notes from for this release.
+- From here on, every real `@gnt-ai/cli` version bump is auto-tagged and
+  auto-noted when it publishes to npm, and public-repo-only activity in between
+  gets a weekly batch release (see `batch-release.yml`).
 
 ## [0.5.7] - 2026-07-21
 
@@ -71,3 +70,17 @@ Pre-changelog release — see npm/git history.
 ## [0.1.0] - 2026-07-15
 
 Pre-changelog release — see npm/git history.
+
+[Unreleased]: https://github.com/gnt-ai/gnt/compare/cli-v0.6.0...HEAD
+[0.6.0]: https://github.com/gnt-ai/gnt/releases/tag/cli-v0.6.0
+[0.5.7]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.7
+[0.5.6]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.6
+[0.5.4]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.4
+[0.5.3]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.3
+[0.5.2]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.2
+[0.5.1]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.1
+[0.5.0]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.5.0
+[0.4.1]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.4.1
+[0.4.0]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.4.0
+[0.3.0]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.3.0
+[0.1.0]: https://www.npmjs.com/package/@gnt-ai/cli/v/0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ even if they touch the same file. A PR that fixes a bug and also refactors the f
 it is two PRs. This isn't bureaucracy: a scoped PR is fast to review and safe to revert on its
 own; a bundled one makes both changes hostage to whichever part is slower to land.
 
+**User-facing changes get a changelog entry.** If your PR changes something a customer or
+contributor would notice (CLI behavior, API responses, docs that ship with a release), add a
+short bullet under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) in the same PR. Don't
+invent detail for pre-changelog versions — just keep the Unreleased section current going
+forward.
+
 **Show it actually works, not just that it compiles.** State how a reviewer can confirm your
 change does what you say, in the PR description:
 


### PR DESCRIPTION
## What & why

Closes #2.

There's no root `CHANGELOG.md` even though `@gnt-ai/cli` is already on npm through `0.6.0`. This adds one in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format so release history has a single in-repo home going forward, and points `CONTRIBUTING.md` at it so user-facing PRs update `## [Unreleased]`.

- `0.6.0` carries the real public-release notes (from the `cli-v0.6.0` GitHub release), dated to the npm publish day.
- `0.1.0`–`0.5.7` are honest pre-changelog placeholders (exact versions from `npm view @gnt-ai/cli versions` — no invented detail, no phantom `0.2.0`/`0.5.5`).

## Test plan

Pure docs — nothing to run. Preview: open `CHANGELOG.md` on this branch on GitHub and confirm Unreleased → 0.6.0 → older versions render cleanly.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same problem — see `CONTRIBUTING.md`'s code conventions.
- [x] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a structured changelog covering the upcoming release, version 0.6.0, and previous releases.
  * Documented automated release tagging and weekly batching for public-repository changes.
  * Added contributor guidance to include user-facing changes in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the root `CHANGELOG.md` using [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and adds a contributor instruction in `CONTRIBUTING.md` to keep the `[Unreleased]` section current going forward.

- **CHANGELOG.md**: Covers `[Unreleased]`, a properly categorised `[0.6.0]` entry (with `### Added` sub-section and bullet points), honest pre-changelog placeholder entries for `0.5.7`–`0.1.0` (npm-verified, no invented versions), and complete reference-style comparison/npm links at the bottom of the file.
- **CONTRIBUTING.md**: Inserts one paragraph instructing contributors to add a short bullet under `## [Unreleased]` for any user-facing change in the same PR as the change itself.

<h3>Confidence Score: 5/5</h3>

Pure documentation change — no code, no configuration, no dependencies modified.

Both files are documentation only. The changelog is well-formed, addresses the Keep a Changelog spec (categorised entries, reference-style links), and the CONTRIBUTING.md addition is clear and correctly scoped. There is nothing here that can break a build or runtime behaviour.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | New file: structured changelog in Keep a Changelog format with `[Unreleased]`, `0.6.0` (with `### Added` categories and bullet points), and honest pre-changelog placeholder entries back to `0.1.0`, with reference-style comparison/npm links at the bottom. |
| CONTRIBUTING.md | Adds a short paragraph directing contributors to add a bullet under `## [Unreleased]` in `CHANGELOG.md` for any user-facing change, inserted cleanly within existing PR-scoping guidance. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Contributor opens PR] --> B{User-facing change?}
    B -- Yes --> C["Add bullet under\n## [Unreleased]\nin CHANGELOG.md"]
    B -- No --> D[No changelog entry needed]
    C --> E[PR merged to main]
    D --> E
    E --> F{npm publish?}
    F -- Yes --> G["Version heading promoted\n[Unreleased] → [X.Y.Z] - date\nauto-tagged by batch-release.yml"]
    F -- No --> H[Stays in Unreleased]
    G --> I["Reference link added\n[X.Y.Z]: github compare URL"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: address changelog review feedback"](https://github.com/gnt-ai/gnt/commit/e9ee5efe011b02a6a06a556306776784596d31ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49709212)</sub>

<!-- /greptile_comment -->