### PR TITLE
test(store): cover source-paths normalizeSourceId and cloneDirFor

### DIFF
--- a/apps/store/test/source-paths.test.ts
+++ b/apps/store/test/source-paths.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cloneDirFor, normalizeSourceId } from "../src/core/source-paths.ts";
+
+/** Direct coverage for the org-id → storage source-id mapping every adapter
+ * shares. A silent drift here orphans existing rows on adapter cutover; the
+ * engine's own validator also rejects raw Better Auth org ids on case/length,
+ * so the shape of this output is load-bearing. */
+
+describe("normalizeSourceId", () => {
+  test("is deterministic for the same org id", () => {
+    const a = normalizeSourceId("org_AbC123");
+    const b = normalizeSourceId("org_AbC123");
+    expect(a).toBe(b);
+  });
+
+  test("different org ids produce different normalized ids", () => {
+    expect(normalizeSourceId("org-one")).not.toBe(normalizeSourceId("org-two"));
+  });
+
+  test("always matches org- + 28 lowercase hex chars (exactly 32 total)", () => {
+    const cases = [
+      "simple",
+      "MixedCaseOrgId",
+      "org_with_underscores",
+      "a".repeat(64),
+      "",
+    ];
+    for (const orgId of cases) {
+      const id = normalizeSourceId(orgId);
+      expect(id).toMatch(/^org-[0-9a-f]{28}$/);
+      expect(id).toHaveLength(32);
+      expect(id.startsWith("org-")).toBe(true);
+    }
+  });
+
+  test("case-folds via hashing — mixed-case input still yields lowercase hex", () => {
+    const id = normalizeSourceId("OrgID_With_UPPER");
+    expect(id).toBe(id.toLowerCase());
+    expect(id).toMatch(/^org-[0-9a-f]{28}$/);
+  });
+
+  test("matches the documented sha256 slice mapping", () => {
+    const orgId = "better-auth-style-id";
+    const expected =
+      "org-" + createHash("sha256").update(orgId).digest("hex").slice(0, 28);
+    expect(normalizeSourceId(orgId)).toBe(expected);
+  });
+});
+
+describe("cloneDirFor", () => {
+  const previous = process.env.GNT_STORE_CLONES_DIR;
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.GNT_STORE_CLONES_DIR;
+    } else {
+      process.env.GNT_STORE_CLONES_DIR = previous;
+    }
+  });
+
+  test("joins sourceId onto GNT_STORE_CLONES_DIR when set", () => {
+    process.env.GNT_STORE_CLONES_DIR = "/var/gnt/clones";
+    expect(cloneDirFor("org-abc")).toBe(join("/var/gnt/clones", "org-abc"));
+  });
+
+  test("falls back to tmpdir/gnt-store-clones when the env var is unset", () => {
+    delete process.env.GNT_STORE_CLONES_DIR;
+    expect(cloneDirFor("org-abc")).toBe(join(tmpdir(), "gnt-store-clones", "org-abc"));
+  });
+});

--- a/apps/store/test/source-paths.test.ts
+++ b/apps/store/test/source-paths.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cloneDirFor, normalizeSourceId } from "../src/core/source-paths.ts";
@@ -36,17 +35,18 @@ describe("normalizeSourceId", () => {
     }
   });
 
-  test("case-folds via hashing — mixed-case input still yields lowercase hex", () => {
-    const id = normalizeSourceId("OrgID_With_UPPER");
-    expect(id).toBe(id.toLowerCase());
-    expect(id).toMatch(/^org-[0-9a-f]{28}$/);
+  test("different casing of the same characters produces different source ids", () => {
+    // Hash is over the raw bytes — no case folding — so callers must not treat
+    // "Abc" and "abc" as interchangeable org ids.
+    expect(normalizeSourceId("Abc")).not.toBe(normalizeSourceId("abc"));
   });
 
-  test("matches the documented sha256 slice mapping", () => {
-    const orgId = "better-auth-style-id";
-    const expected =
-      "org-" + createHash("sha256").update(orgId).digest("hex").slice(0, 28);
-    expect(normalizeSourceId(orgId)).toBe(expected);
+  test("matches a hardcoded golden sha256 slice mapping", () => {
+    // Golden: printf '%s' 'better-auth-style-id' | shasum -a 256 | cut -c1-28
+    // Hardcoded so a hash/prefix/slice change fails independently of this file.
+    expect(normalizeSourceId("better-auth-style-id")).toBe(
+      "org-f261f82fd67403939b29e499e8fb",
+    );
   });
 });
 


### PR DESCRIPTION
## What & why

Closes #20.

`apps/store/src/core/source-paths.ts` is the shared org-id → storage source-id mapping every adapter has to agree on, and it had no direct tests. This adds `apps/store/test/source-paths.test.ts` covering:

- `normalizeSourceId` determinism, uniqueness across distinct org ids, and the exact `org-` + 28 lowercase hex / 32-char shape the engine validator requires
- case-insensitive hex output for mixed-case org ids
- the documented sha256 slice mapping
- `cloneDirFor` using `GNT_STORE_CLONES_DIR` when set, and falling back to `tmpdir()/gnt-store-clones` when not

## Test plan

```bash
cd apps/store && bun test test/source-paths.test.ts
```

Locally: **7 pass / 0 fail**.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same problem — see `CONTRIBUTING.md`'s code conventions.
- [x] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for consistent source identifier generation, including formatting, length, casing, and documented mappings.
  * Added coverage for clone directory selection using configured and default locations.
  * Ensured environment settings are restored after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds first-party tests for `apps/store/src/core/source-paths.ts`, the load-bearing `orgId → sourceId` mapping shared across all storage adapters. The two previously-raised issues (misleading case-insensitivity test name, computed rather than golden expected value) have both been fixed in this revision.

- `normalizeSourceId` is covered by five tests: determinism, cross-org uniqueness, output shape (`/^org-[0-9a-f]{28}$/`, 32 chars), case-sensitivity (raw bytes, no folding), and a hardcoded sha256-slice golden value so algorithm drift fails independently.
- `cloneDirFor` is covered by two tests (env-override path and `tmpdir` fallback) with correct `afterEach` env restoration using the module-level `previous` snapshot.

<h3>Confidence Score: 5/5</h3>

Test-only addition that adds no production code changes; all assertions target clearly observable properties of a pure, stable function.

The change is entirely additive tests over an existing, unchanged production module. Both previously flagged issues have been corrected — the misleading case-fold test name is gone, and the expected hash value is now a hardcoded golden string with a derivation comment. The env-var cleanup in cloneDirFor tests correctly snapshots the initial value once and restores it after each test.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/store/test/source-paths.test.ts | New test file covering normalizeSourceId (determinism, uniqueness, shape, case-sensitivity, golden mapping) and cloneDirFor (env override and default fallback); previous-thread issues addressed — misleading test name corrected and hardcoded golden value added. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(store): clarify casing behavior and..."](https://github.com/gnt-ai/gnt/commit/e757fe635bc5265a6d4d5f56dfb69a0babdc4bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49709332)</sub>

<!-- /greptile_comment -->