### PR TITLE
test(cli): cover gnt pull download and filename sanitization

### DIFF
--- a/apps/cli/test/pull.test.ts
+++ b/apps/cli/test/pull.test.ts
@@ -183,15 +183,35 @@ test("strips path components from a traversal-shaped Content-Disposition filenam
   expect(output()).toContain("Saved passwd (3B)");
 });
 
-test("falls back to gnt-pack.zip when Content-Disposition is missing or unsafe", async () => {
+test("falls back to gnt-pack.zip when Content-Disposition is missing", async () => {
   const body = new Uint8Array([4, 5]);
-  mockZipResponse({ body, contentDisposition: "attachment; filename=.." });
+  mockZipResponse({ body, contentDisposition: null });
 
   await pull();
 
   expect(existsSync(join(workDir, "gnt-pack.zip"))).toBe(true);
   expect(readFileSync(join(workDir, "gnt-pack.zip"))).toEqual(Buffer.from(body));
   expect(output()).toContain("Saved gnt-pack.zip (2B)");
+});
+
+test("falls back to gnt-pack.zip when Content-Disposition filename is '.'", async () => {
+  const body = new Uint8Array([6]);
+  mockZipResponse({ body, contentDisposition: "attachment; filename=." });
+
+  await pull();
+
+  expect(existsSync(join(workDir, "gnt-pack.zip"))).toBe(true);
+  expect(output()).toContain("Saved gnt-pack.zip (1B)");
+});
+
+test("falls back to gnt-pack.zip when Content-Disposition filename is '..'", async () => {
+  const body = new Uint8Array([7]);
+  mockZipResponse({ body, contentDisposition: "attachment; filename=.." });
+
+  await pull();
+
+  expect(existsSync(join(workDir, "gnt-pack.zip"))).toBe(true);
+  expect(output()).toContain("Saved gnt-pack.zip (1B)");
 });
 
 test("strips absolute path components from Content-Disposition before writing", async () => {

--- a/apps/cli/test/pull.test.ts
+++ b/apps/cli/test/pull.test.ts
@@ -1,0 +1,210 @@
+// Set a temporary config directory before importing the command modules so
+// this file never reads or writes a user's real ~/.gnt/credentials.json.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-pull-test-"));
+const previousConfigDir = process.env.GNT_CONFIG_DIR;
+process.env.GNT_CONFIG_DIR = testConfigDir;
+
+const { saveApiKey } = await import("../src/credentials.js");
+const { pull } = await import("../src/commands/pull.js");
+
+if (previousConfigDir === undefined) {
+  delete process.env.GNT_CONFIG_DIR;
+} else {
+  process.env.GNT_CONFIG_DIR = previousConfigDir;
+}
+
+const credentialsPath = join(testConfigDir, "credentials.json");
+
+let originalFetch: typeof fetch;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+let originalCwd: string;
+let workDir: string;
+
+let logs: string[];
+let errors: string[];
+let exitCalls: number[];
+
+// eslint-disable-next-line no-control-regex -- strips terminal ANSI color sequences before assertions.
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+
+function output() {
+  return logs.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function errorOutput() {
+  return errors.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function mockZipResponse(opts: {
+  status?: number;
+  body?: Uint8Array | string;
+  contentDisposition?: string | null;
+}) {
+  const status = opts.status ?? 200;
+  const body = opts.body ?? new Uint8Array([1, 2, 3, 4]);
+  const headers = new Headers();
+  if (opts.contentDisposition !== null) {
+    headers.set(
+      "Content-Disposition",
+      // Match the API's unquoted form (skill_packs.py): filename=gnt-pack-v{n}.zip
+      opts.contentDisposition ?? "attachment; filename=gnt-pack-v3.zip",
+    );
+  }
+  globalThis.fetch = mock(() =>
+    Promise.resolve(new Response(body, { status, headers })),
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+  originalCwd = process.cwd();
+
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  saveApiKey("gnt_live_test_key", "key-id");
+
+  workDir = mkdtempSync(join(tmpdir(), "gnt-pull-cwd-"));
+  process.chdir(workDir);
+
+  logs = [];
+  errors = [];
+  exitCalls = [];
+
+  console.log = (...args: unknown[]) => {
+    logs.push(args.join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args.join(" "));
+  };
+
+  process.exit = ((code?: number | string) => {
+    exitCalls.push(Number(code));
+    throw new Error("test process exit");
+  }) as unknown as typeof process.exit;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(workDir, { recursive: true, force: true });
+
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+
+  rmSync(credentialsPath, { force: true });
+
+  if (previousConfigDir === undefined) {
+    delete process.env.GNT_CONFIG_DIR;
+  } else {
+    process.env.GNT_CONFIG_DIR = previousConfigDir;
+  }
+});
+
+test("prints No skill pack yet on 404 without exiting", async () => {
+  mockZipResponse({ status: 404, body: "" });
+
+  await pull();
+
+  expect(output()).toContain("No skill pack yet.");
+  expect(exitCalls).toEqual([]);
+  expect(existsSync(join(workDir, "gnt-pack.zip"))).toBe(false);
+});
+
+test("prints an error and exits on a non-ok, non-404 response", async () => {
+  mockZipResponse({ status: 500, body: "" });
+
+  await expect(pull()).rejects.toThrow("test process exit");
+
+  expect(errorOutput()).toContain("Failed to download skill pack (500).");
+  expect(exitCalls).toEqual([1]);
+});
+
+test("saves the zip under the Content-Disposition filename and reports size in B", async () => {
+  const body = new Uint8Array(500).fill(7);
+  mockZipResponse({
+    body,
+    contentDisposition: "attachment; filename=pack-small.zip",
+  });
+
+  await pull();
+
+  const saved = join(workDir, "pack-small.zip");
+  expect(existsSync(saved)).toBe(true);
+  expect(readFileSync(saved)).toEqual(Buffer.from(body));
+  expect(output()).toContain("Saved pack-small.zip (500B)");
+});
+
+test("reports KB for sizes between 1KB and 1MB", async () => {
+  const body = new Uint8Array(2048).fill(1);
+  mockZipResponse({
+    body,
+    contentDisposition: "attachment; filename=pack-kb.zip",
+  });
+
+  await pull();
+
+  expect(output()).toContain("Saved pack-kb.zip (2.0KB)");
+});
+
+test("reports MB for sizes at or over 1MB", async () => {
+  const body = new Uint8Array(1024 * 1024).fill(1);
+  mockZipResponse({
+    body,
+    contentDisposition: "attachment; filename=pack-mb.zip",
+  });
+
+  await pull();
+
+  expect(output()).toContain("Saved pack-mb.zip (1.0MB)");
+});
+
+test("strips path components from a traversal-shaped Content-Disposition filename", async () => {
+  const body = new Uint8Array([9, 9, 9]);
+  mockZipResponse({
+    body,
+    contentDisposition: "attachment; filename=../../etc/passwd",
+  });
+
+  await pull();
+
+  expect(existsSync(join(workDir, "passwd"))).toBe(true);
+  expect(existsSync(join(workDir, "etc"))).toBe(false);
+  expect(readFileSync(join(workDir, "passwd"))).toEqual(Buffer.from(body));
+  expect(output()).toContain("Saved passwd (3B)");
+});
+
+test("falls back to gnt-pack.zip when Content-Disposition is missing or unsafe", async () => {
+  const body = new Uint8Array([4, 5]);
+  mockZipResponse({ body, contentDisposition: "attachment; filename=.." });
+
+  await pull();
+
+  expect(existsSync(join(workDir, "gnt-pack.zip"))).toBe(true);
+  expect(readFileSync(join(workDir, "gnt-pack.zip"))).toEqual(Buffer.from(body));
+  expect(output()).toContain("Saved gnt-pack.zip (2B)");
+});
+
+test("strips absolute path components from Content-Disposition before writing", async () => {
+  const body = new Uint8Array([8]);
+  mockZipResponse({
+    body,
+    contentDisposition: "attachment; filename=/tmp/evil.zip",
+  });
+
+  await pull();
+
+  // Only the basename is used — never the raw /tmp/... path.
+  expect(existsSync(join(workDir, "evil.zip"))).toBe(true);
+  expect(existsSync(join(workDir, "tmp"))).toBe(false);
+  expect(output()).toContain("Saved evil.zip (1B)");
+});


### PR DESCRIPTION
## What & why

Closes #10.

`gnt pull` had no test coverage despite real branching (404 vs error vs success), `formatSize` boundaries, and Content-Disposition sanitization before a local `writeFileSync`. This adds `apps/cli/test/pull.test.ts` covering:

- 404 → "No skill pack yet." and no `process.exit`
- non-ok/non-404 → fail message + `process.exit(1)`
- successful write under the header filename, with `B` / `KB` / `MB` size formatting via the Saved line
- path-traversal and absolute-path headers stripped to a basename (or `gnt-pack.zip` for `.`/`..`)

## Test plan

```bash
cd apps/cli && bun test test/pull.test.ts
```

Locally: **8 pass / 0 fail**.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same problem — see `CONTRIBUTING.md`'s code conventions.
- [x] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for pull-command error handling and failed responses.
  * Verified safe filename handling, including path sanitization and fallback behavior.
  * Added checks for extracting filenames and formatting downloaded file sizes in bytes, kilobytes, and megabytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `apps/cli/test/pull.test.ts`, providing the first test coverage for the `gnt pull` command. It addresses both gaps called out in a previous review thread — the missing-header path and the `filename=.` edge case — and also covers 404 / non-ok error handling, three `formatSize` size ranges, path-traversal stripping, and absolute-path stripping.

- **Error paths** (404 and non-ok): verified that "No skill pack yet." is logged without calling `process.exit`, and that a 500 logs the failure message and calls `process.exit(1)`.
- **Filename sanitization** (five tests): path-traversal `../../etc/passwd → passwd`, absolute `/tmp/evil.zip → evil.zip`, `filename=.`, `filename=..`, and missing header all fall back safely to `gnt-pack.zip`.
- **Size formatting** (three tests): bytes (500 B), kilobytes (2 048 B → 2.0 KB), and megabytes (1 MiB → 1.0 MB) each verified with a real `Uint8Array` body and a filesystem read.

<h3>Confidence Score: 5/5</h3>

Test-only change; no production code is modified and the new tests exercise the real implementation against a real temp filesystem.

The change is purely additive test code. The mocking, CWD isolation via process.chdir, and teardown logic are all correct. All previously flagged coverage gaps (filename=., missing header) are addressed, and the optional-chaining chain in pull.ts propagates undefined correctly so the missing-header path does reach the gnt-pack.zip fallback as the test expects.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/test/pull.test.ts | New test file adding 8 cases for pull command — all previously flagged gaps (missing header, filename=.) are now covered; mocking, teardown, and CWD isolation are correct. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant M as mockZipResponse
    participant P as pull()
    participant FS as writeFileSync

    T->>M: set globalThis.fetch mock
    T->>P: call pull()
    P->>P: loadApiKey()
    P->>M: fetch(API_URL/skill-packs/latest.zip)
    M-->>P: Response(status, headers, body)

    alt "status === 404"
        P->>T: console.log("No skill pack yet.")
        P-->>T: return (no exit)
    else !res.ok
        P->>T: console.error("Failed to download...")
        P->>T: process.exit(1) → throws
    else ok
        P->>P: parse Content-Disposition filename
        P->>P: basename sanitization (strip paths, reject . / ..)
        P->>FS: writeFileSync(filename, buffer)
        P->>T: console.log("Saved filename (size)")
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): cover missing and dot Content..."](https://github.com/gnt-ai/gnt/commit/7b839212a60e0f149e3a70ce8ac3482eaed13059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49709586)</sub>

<!-- /greptile_comment -->