### PR TITLE
test(cli): cover gnt keys list/create/revoke/rotate

### DIFF
--- a/apps/cli/test/keys.test.ts
+++ b/apps/cli/test/keys.test.ts
@@ -195,11 +195,38 @@ test("rotates a key and notes that the old id is now revoked", async () => {
   expect(output()).toContain("old-key-id is now revoked");
 });
 
-test("prints an error and exits when the API response is not ok", async () => {
+test("prints an error and exits when createKey gets a non-ok response", async () => {
   mockFetch({}, 500);
 
   await expect(createKey()).rejects.toThrow("test process exit");
 
   expect(errorOutput()).toContain("Failed to create key (500).");
+  expect(exitCalls).toEqual([1]);
+});
+
+test("prints an error and exits when listKeys gets a non-ok response", async () => {
+  mockFetch({}, 500);
+
+  await expect(listKeys()).rejects.toThrow("test process exit");
+
+  expect(errorOutput()).toContain("Failed to list keys (500).");
+  expect(exitCalls).toEqual([1]);
+});
+
+test("prints an error and exits when revokeKey gets a non-ok response", async () => {
+  mockFetch({}, 500);
+
+  await expect(revokeKey("some-id")).rejects.toThrow("test process exit");
+
+  expect(errorOutput()).toContain("Failed to revoke key (500).");
+  expect(exitCalls).toEqual([1]);
+});
+
+test("prints an error and exits when rotateKey gets a non-ok response", async () => {
+  mockFetch({}, 500);
+
+  await expect(rotateKey("some-id")).rejects.toThrow("test process exit");
+
+  expect(errorOutput()).toContain("Failed to rotate key (500).");
   expect(exitCalls).toEqual([1]);
 });

--- a/apps/cli/test/keys.test.ts
+++ b/apps/cli/test/keys.test.ts
@@ -1,0 +1,205 @@
+// Set a temporary config directory before importing the command modules so
+// this file never reads or writes a user's real ~/.gnt/credentials.json.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-keys-test-"));
+const previousConfigDir = process.env.GNT_CONFIG_DIR;
+process.env.GNT_CONFIG_DIR = testConfigDir;
+
+const { saveApiKey } = await import("../src/credentials.js");
+const { createKey, listKeys, revokeKey, rotateKey } = await import("../src/commands/keys.js");
+
+// Bun loads all test files into one process. Restore the prior value after
+// imports so this file cannot affect another file's module setup.
+if (previousConfigDir === undefined) {
+  delete process.env.GNT_CONFIG_DIR;
+} else {
+  process.env.GNT_CONFIG_DIR = previousConfigDir;
+}
+
+const credentialsPath = join(testConfigDir, "credentials.json");
+
+let originalFetch: typeof fetch;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+
+let logs: string[];
+let errors: string[];
+let exitCalls: number[];
+let fetchCalls: Array<{ input: string; init?: RequestInit }>;
+
+// eslint-disable-next-line no-control-regex -- strips terminal ANSI color sequences before assertions.
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+
+function output() {
+  return logs.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function errorOutput() {
+  return errors.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+// Install a fake fetch: record requests and return a supplied API response.
+function mockFetch(body: unknown, status = 200) {
+  const fetchMock = mock((input: string | URL | Request, init?: RequestInit) => {
+    fetchCalls.push({ input: String(input), init });
+
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+
+  // credentials.ts reads this environment variable at call time.
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  saveApiKey("gnt_live_test_key", "key-id");
+
+  logs = [];
+  errors = [];
+  exitCalls = [];
+  fetchCalls = [];
+
+  console.log = (...args: unknown[]) => {
+    logs.push(args.join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args.join(" "));
+  };
+
+  // Keep the error-path test from terminating Bun itself.
+  process.exit = ((code?: number | string) => {
+    exitCalls.push(Number(code));
+    throw new Error("test process exit");
+  }) as unknown as typeof process.exit;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+
+  rmSync(credentialsPath, { force: true });
+
+  if (previousConfigDir === undefined) {
+    delete process.env.GNT_CONFIG_DIR;
+  } else {
+    process.env.GNT_CONFIG_DIR = previousConfigDir;
+  }
+});
+
+test("prints a message when there are no MCP keys", async () => {
+  mockFetch([]);
+
+  await listKeys();
+
+  expect(output()).toContain("No MCP keys yet. Create one with `gnt keys create`.");
+});
+
+test("lists aligned MCP keys with revoked, used, and unused states", async () => {
+  mockFetch([
+    {
+      id: "a",
+      name: "short",
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: null,
+      revoked_at: null,
+      expires_at: null,
+    },
+    {
+      id: "much-longer-key-id",
+      name: "a longer key name",
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: "2026-08-02T08:30:00Z",
+      revoked_at: null,
+      expires_at: null,
+    },
+    {
+      id: "revoked-id",
+      name: null,
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: null,
+      revoked_at: "2026-08-02T09:00:00Z",
+      expires_at: null,
+    },
+  ]);
+
+  await listKeys();
+
+  // \s+ accepts the variable padding introduced by padEnd column alignment.
+  expect(output()).toMatch(/^a\s+short\s+unused$/m);
+  expect(output()).toMatch(
+    /^much-longer-key-id\s+a longer key name\s+last used 2026-08-02T08:30:00Z$/m,
+  );
+  expect(output()).toMatch(/^revoked-id\s+\(unnamed\)\s+revoked$/m);
+});
+
+test("creates an unnamed MCP key with name set to null", async () => {
+  mockFetch({ key: "gnt_mcp_new_key" });
+
+  await createKey();
+
+  expect(fetchCalls).toHaveLength(1);
+  expect(new URL(fetchCalls[0]!.input).pathname).toBe("/v1/settings/mcp-keys");
+  expect(fetchCalls[0]!.init?.method).toBe("POST");
+  expect(fetchCalls[0]!.init?.body).toBe('{"name":null}');
+  expect(output()).toContain("gnt_mcp_new_key");
+  expect(output()).toContain("This is shown once — copy it now.");
+});
+
+test("creates a named MCP key and prints the MCP URL", async () => {
+  mockFetch({ key: "gnt_mcp_named" });
+
+  await createKey("my key");
+
+  expect(fetchCalls[0]!.init?.body).toBe('{"name":"my key"}');
+  expect(output()).toContain("MCP URL:");
+  expect(output()).toContain("/mcp/");
+  expect(output()).toContain("gnt_mcp_named");
+});
+
+test("revokes the requested MCP key", async () => {
+  mockFetch({});
+
+  await revokeKey("some-id");
+
+  expect(new URL(fetchCalls[0]!.input).pathname).toBe("/v1/settings/mcp-keys/some-id/revoke");
+  expect(fetchCalls[0]!.init?.method).toBe("POST");
+  expect(output()).toContain("Revoked some-id");
+});
+
+test("rotates a key and notes that the old id is now revoked", async () => {
+  mockFetch({ key: "gnt_mcp_rotated" });
+
+  await rotateKey("old-key-id");
+
+  expect(new URL(fetchCalls[0]!.input).pathname).toBe("/v1/settings/mcp-keys/old-key-id/rotate");
+  expect(fetchCalls[0]!.init?.method).toBe("POST");
+  expect(output()).toContain("gnt_mcp_rotated");
+  expect(output()).toContain("old-key-id is now revoked");
+});
+
+test("prints an error and exits when the API response is not ok", async () => {
+  mockFetch({}, 500);
+
+  await expect(createKey()).rejects.toThrow("test process exit");
+
+  expect(errorOutput()).toContain("Failed to create key (500).");
+  expect(exitCalls).toEqual([1]);
+});


### PR DESCRIPTION
## What & why

Closes #13.

`gnt keys list|create|revoke|rotate` had zero test coverage. This adds `apps/cli/test/keys.test.ts` in the same shape as the recently added webhook tests:

- empty list → "No MCP keys yet…"
- padded columns + `unused` / `last used …` / `revoked` status lines
- `createKey()` posts `{"name":null}` (literal null, not omitted)
- named create prints MCP URL + key + shown-once notice
- revoke / rotate hit the right paths; rotate's message notes the old id is revoked
- non-ok → fail + `process.exit(1)`

## Test plan

```bash
cd apps/cli && bun test test/keys.test.ts
```

Locally: **7 pass / 0 fail**.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same problem — see `CONTRIBUTING.md`'s code conventions.
- [x] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `apps/cli/test/keys.test.ts`, providing first test coverage for the `gnt keys list|create|revoke|rotate` commands. The file follows the same structure and isolation strategy as the recently merged `webhook.test.ts`.

- **Happy-path coverage**: all four exported functions are exercised — empty list, padded column alignment, unnamed/named create, revoke, and rotate outputs are all asserted.
- **Error-path coverage**: dedicated `!res.ok → process.exit(1)` tests for every command (addressing the previous reviewer note), all four asserting the correct error message and exit code.
- **Test isolation**: a per-run temp dir for `GNT_CONFIG_DIR`, plus full restoration of `globalThis.fetch`, `console.log/error`, and `process.exit` in `afterEach`, match the existing webhook test pattern exactly.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; safe to merge.

The change is purely additive test coverage — no production logic is touched. All four command functions are exercised across both happy paths and error paths, globals are properly saved and restored in afterEach, and the file faithfully follows the established webhook.test.ts pattern.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/test/keys.test.ts | New test file adding 10 tests covering all four key commands' happy paths and error paths; correctly mirrors webhook.test.ts patterns with proper global teardown and env isolation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): cover non-ok exits for all gn..."](https://github.com/gnt-ai/gnt/commit/c1e949bfb78ce617f2454027e2c8fc954713da28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49709642)</sub>

<!-- /greptile_comment -->