### PR TITLE
readme: switch badges to shieldcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </picture>
 </a>
 
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE) [![npm](https://img.shields.io/npm/v/@gnt-ai/cli)](https://www.npmjs.com/package/@gnt-ai/cli) [![CI](https://github.com/gnt-ai/gnt/actions/workflows/ci.yml/badge.svg)](https://github.com/gnt-ai/gnt/actions/workflows/ci.yml)
+[![License](https://shieldcn.dev/github/license/gnt-ai/gnt.svg?variant=secondary)](LICENSE) [![npm](https://shieldcn.dev/npm/@gnt-ai/cli.svg?variant=secondary)](https://www.npmjs.com/package/@gnt-ai/cli) [![CI](https://github.com/gnt-ai/gnt/actions/workflows/ci.yml/badge.svg)](https://github.com/gnt-ai/gnt/actions/workflows/ci.yml)
 
 </div>
 
@@ -207,6 +207,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for dev setup and how to open a PR. Eve
 
 <div align="center">
 
-[![Discussions](https://img.shields.io/badge/discussions-github-blue)](https://github.com/gnt-ai/gnt/discussions) [![Issues](https://img.shields.io/github/issues/gnt-ai/gnt)](https://github.com/gnt-ai/gnt/issues) [![Code of conduct](https://img.shields.io/badge/code%20of%20conduct-CODE__OF__CONDUCT.md-lightgrey)](CODE_OF_CONDUCT.md)
+[![Discussions](https://shieldcn.dev/badge/discussions-github.svg?variant=secondary)](https://github.com/gnt-ai/gnt/discussions) [![Issues](https://shieldcn.dev/github/issues/gnt-ai/gnt.svg?variant=secondary)](https://github.com/gnt-ai/gnt/issues) [![Code of conduct](https://shieldcn.dev/badge/code%20of%20conduct-CODE_OF_CONDUCT.md.svg?variant=secondary)](CODE_OF_CONDUCT.md)
 
 </div>


### PR DESCRIPTION
Same shields.io data, styled as shadcn button pills instead of the flat default look.

Left CI on its original GitHub Actions badge -- tested shieldcn's own /github/ci endpoint first, it reported "failing" for this repo when the real latest run on main actually succeeded (checked directly against the Actions API, tried a branch=main param too, same wrong result). Not shipping a badge that lies about build health.

Every other badge verified against real data before use: license text matches LICENSE, npm version matches the published version, issue count matches `gh issue list` once you account for GitHub folding open PRs into the raw issue count.

## Test plan
- Fetched and rendered every badge URL as a PNG to visually confirm correct data before committing to the swap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badge image links to use shieldcn.dev while preserving existing labels and destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the shields.io badge image URLs in `README.md` with shieldcn.dev equivalents styled as shadcn button pills via `?variant=secondary`. The CI badge is intentionally left on its original GitHub Actions URL after the author found shieldcn's `/github/ci` endpoint reported an incorrect status.

- Dynamic provider endpoints (`/github/license`, `/npm/@gnt-ai/cli`, `/github/issues`) correctly match the shieldcn documented URL patterns and are straightforward replacements for their shields.io counterparts.
- Static badges (`Discussions`, `Code of conduct`) and the CI badge complete the badge row; the author notes all badge data was visually verified against live sources before committing.

<h3>Confidence Score: 5/5</h3>

Documentation-only change swapping badge image hosts; no logic, build, or runtime code is touched.

All dynamic shieldcn endpoint paths match the documented provider URL patterns, the CI badge is deliberately unchanged, and the author verified rendered output for every badge before committing. No functional code is affected.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Switches five badge image URLs from shields.io to shieldcn.dev; CI badge intentionally retained on GitHub Actions; dynamic provider endpoints (license, npm, issues) match the shieldcn documented URL patterns correctly. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into readme-shieldcn..."](https://github.com/gnt-ai/gnt/commit/0805a48b3bd643b2b10bf5bb4098205824b43060) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49711117)</sub>

<!-- /greptile_comment -->