### PR TITLE
readme: swap CI badge for release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </picture>
 </a>
 
-[![License](https://shieldcn.dev/github/license/gnt-ai/gnt.svg?variant=secondary)](LICENSE) [![npm](https://shieldcn.dev/npm/@gnt-ai/cli.svg?variant=secondary)](https://www.npmjs.com/package/@gnt-ai/cli) [![CI](https://github.com/gnt-ai/gnt/actions/workflows/ci.yml/badge.svg)](https://github.com/gnt-ai/gnt/actions/workflows/ci.yml)
+[![License](https://shieldcn.dev/github/license/gnt-ai/gnt.svg?variant=secondary)](LICENSE) [![npm](https://shieldcn.dev/npm/@gnt-ai/cli.svg?variant=secondary)](https://www.npmjs.com/package/@gnt-ai/cli) [![Release](https://shieldcn.dev/github/release/gnt-ai/gnt.svg?variant=secondary)](https://github.com/gnt-ai/gnt/releases/latest)
 
 </div>
 


### PR DESCRIPTION
CI pass/fail isn't a signal worth leading with on a README. Swapped for the latest release tag instead (shieldcn, same secondary variant as the other badges).

## Test plan
- Fetched the badge URL and rendered it to confirm it shows the real latest release (cli-v0.6.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the CI status badge in the README with a badge linking to the latest GitHub release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR swaps the GitHub Actions CI badge for a release badge on the README, using the same `shieldcn.dev` host and `?variant=secondary` style as the existing License and npm badges.

- The old CI badge pointed directly to the GitHub Actions workflow; the new badge (`shieldcn.dev/github/release/gnt-ai/gnt.svg`) links to `github.com/gnt-ai/gnt/releases/latest`, which is the correct canonical URL for the latest release.
- No functional code is touched; the change is documentation-only.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no code paths are affected.

A single badge URL is replaced with a new one that uses the same third-party host and style as the two badges already present. The new link correctly targets the GitHub releases page, and the badge source is consistent with the rest of the README.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Replaces the GitHub Actions CI status badge with a shieldcn.dev release badge linking to the latest release; consistent styling with the other two badges. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README badge row] --> B[License badge\nshieldcn.dev]
    A --> C[npm badge\nshieldcn.dev]
    A --> D{Badge swapped}
    D -- before --> E[CI badge\ngithub.com/actions]
    D -- after --> F[Release badge\nshieldcn.dev → releases/latest]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["readme: swap the CI badge for a release ..."](https://github.com/gnt-ai/gnt/commit/38e0b8f303821a8ecffac202e3f4c6f01647f4d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49730655)</sub>

<!-- /greptile_comment -->