### PR TITLE
security: bump brace-expansion/postcss overrides past follow-up CVEs

### DIFF
--- a/apps/store/bun.lock
+++ b/apps/store/bun.lock
@@ -21,7 +21,7 @@
   },
   "overrides": {
     "@hono/node-server": "^2.0.5",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.4",
     "minimatch": "^10.2.5",
   },
@@ -94,7 +94,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -30,7 +30,7 @@
   "overrides": {
     "@hono/node-server": "^2.0.5",
     "fast-uri": "^3.1.4",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "minimatch": "^10.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ settings:
 
 overrides:
   '@hono/node-server@<2.0.5': ^2.0.5
-  brace-expansion@<5.0.8: ^5.0.8
+  brace-expansion@<5.0.9: ^5.0.9
   minimatch@<9: ^10.2.5
   drizzle-orm@<0.45.2: ^0.45.2
   lodash@<=4.17.23: ^4.17.24
   lodash@>=4.0.0 <=4.17.22: ^4.17.23
   lodash@>=4.0.0 <=4.17.23: ^4.17.24
-  postcss@<8.5.18: ^8.5.18
+  postcss@<8.5.23: ^8.5.23
   sharp@<0.35.0: ^0.35.3
   fast-uri@<=3.1.3: ^3.1.4
   valibot@<=1.4.1: ^1.4.2
@@ -2216,8 +2216,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   bs58@6.0.0:
@@ -3452,8 +3452,8 @@ packages:
     resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3632,8 +3632,8 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-node@5.46.1:
@@ -6460,7 +6460,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8046,7 +8046,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
@@ -8077,7 +8077,7 @@ snapshots:
 
   nanoevents@9.1.0: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.16: {}
 
@@ -8281,9 +8281,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.19:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9039,7 +9039,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,15 +39,19 @@ minimumReleaseAgeExclude:
   - lodash@4.17.23 || 4.17.24
   - drizzle-orm@0.45.2
   - '@hono/node-server@2.0.5'
-  - postcss@8.5.18
+  - postcss@8.5.23
   - sharp@0.35.3
   - fast-uri@3.1.4
   - next@16.2.11
   - valibot@1.4.2
-  - brace-expansion@5.0.8
+  - brace-expansion@5.0.9
 overrides:
   '@hono/node-server@<2.0.5': ^2.0.5
-  brace-expansion@<5.0.8: ^5.0.8
+  # 5.0.8 (the prior pin here) turned out to only fix CVE-2026-14257's
+  # first reported shape -- a follow-up advisory found the same DoS
+  # reachable through 5.0.8's own unbounded intermediate arrays, patched
+  # in 5.0.9. Bumping the floor, not adding a second override line.
+  brace-expansion@<5.0.9: ^5.0.9
   # @eslint/config-array pins minimatch@^3.1.5, whose own brace-expansion
   # usage (`require("brace-expansion")` expecting a callable default
   # export) breaks against brace-expansion@5.x's new export shape -- the
@@ -60,7 +64,12 @@ overrides:
   lodash@<=4.17.23: ^4.17.24
   lodash@>=4.0.0 <=4.17.22: ^4.17.23
   lodash@>=4.0.0 <=4.17.23: ^4.17.24
-  postcss@<8.5.18: ^8.5.18
+  # 8.5.18 (the prior pin here) only carried GHSA-6g55-p6wh-862q's first
+  # fix -- an incomplete-fix follow-up (attacker-controlled
+  # sourceMappingURL still reading arbitrary .map files when `from` is
+  # unset) needed 8.5.23. Same bump-the-floor reasoning as brace-expansion
+  # above.
+  postcss@<8.5.23: ^8.5.23
   sharp@<0.35.0: ^0.35.3
   fast-uri@<=3.1.3: ^3.1.4
   valibot@<=1.4.1: ^1.4.2


### PR DESCRIPTION
Both existing pins in pnpm-workspace.yaml (brace-expansion 5.0.8, postcss 8.5.18) only covered the first published advisory for each. Follow-up CVEs found the same bugs still reachable in those exact versions:

- brace-expansion: DoS via unbounded intermediate arrays, bypassing the original mitigation. Needs 5.0.9.
- postcss: incomplete sourceMappingURL fix, still reading attacker-controlled paths when `from` is unset. Needs 8.5.23.

Bumped the floor on both instead of adding a second override line for the same package. apps/store runs its own bun.lock outside the pnpm workspace, so it carries the same brace-expansion pin independently — bumped there too, and bun audit confirmed the same finding before the fix.

Left the open react-router Dependabot alert alone — already correctly suppressed via `auditConfig.ignoreGhsas` (react-router's RSC-only CSRF bypass has no attack surface in zudoku's static Vite build, and no patched release exists yet to bump to anyway).

Test plan:
- `pnpm audit` and `bun audit` (apps/store) — both clean
- eslint/typecheck across the workspace — clean
- docs build (zudoku's vite chain pulls in postcss) — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package maintenance settings to incorporate the latest security fixes.
  * Improved safeguards for newly released package versions.
  * Kept workspace version requirements aligned for more consistent installations and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps two security override floors in `pnpm-workspace.yaml` and `apps/store/package.json` to address follow-up CVEs that bypassed earlier mitigations: `brace-expansion` 5.0.8 → 5.0.9 (unbounded intermediate-array DoS, CVE-2026-45149) and `postcss` 8.5.18 → 8.5.23 (incomplete `sourceMappingURL` path-traversal fix, CVE-2026-69153). Lock files for both the pnpm workspace and the standalone Bun store app are regenerated accordingly.

- `brace-expansion` override and `minimumReleaseAgeExclude` entry both set to `5.0.9`, matching the resolved lock-file version exactly.
- `postcss` override floor set to `^8.5.23`, but pnpm resolves to `8.5.25`; the `minimumReleaseAgeExclude` entry was updated to `8.5.23` rather than `8.5.25`, creating a mismatch with the installed version.
- `nanoid` bumps transitively from `3.3.15` to `3.3.16` as a postcss dependency; this is unlisted in the PR description but benign.

<h3>Confidence Score: 4/5</h3>

Safe to merge after verifying or correcting the postcss minimumReleaseAgeExclude entry; the security bumps themselves are correct and well-motivated.

The brace-expansion half of this PR is clean — override floor, lock file, and minimumReleaseAgeExclude all agree on 5.0.9. The postcss half installs 8.5.25 but exempts 8.5.23 from the minimum-release-age check, so a fresh install on an environment where that policy is active would find 8.5.25 unexempted. Everything else (hashes, resolved versions, audit suppression rationale) looks correct.

**Files Needing Attention:** pnpm-workspace.yaml — specifically the minimumReleaseAgeExclude entry for postcss.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Bumps brace-expansion floor to 5.0.9 and postcss floor to 8.5.23; minimumReleaseAgeExclude for postcss lists 8.5.23 but the lock resolves to 8.5.25, creating a mismatch. |
| pnpm-lock.yaml | Lock file regenerated; brace-expansion 5.0.8→5.0.9, postcss 8.5.19→8.5.25 (with transitive nanoid 3.3.15→3.3.16), hashes match published packages. |
| apps/store/package.json | brace-expansion override floor correctly updated from ^5.0.8 to ^5.0.9 in Bun workspace's overrides block. |
| apps/store/bun.lock | brace-expansion 5.0.8→5.0.9 with updated integrity hash; consistent with package.json override. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm-workspace.yaml overrides] --> B["brace-expansion@<5.0.9: ^5.0.9"]
    A --> C["postcss@<8.5.23: ^8.5.23"]

    B --> D["Resolves: brace-expansion@5.0.9 ✓"]
    C --> E["Resolves: postcss@8.5.25"]
    E --> F["nanoid@3.3.16 (transitive)"]

    D --> G["minimumReleaseAgeExclude: brace-expansion@5.0.9 ✓ (matches)"]
    E --> H["minimumReleaseAgeExclude: postcss@8.5.23 ⚠ (mismatch — 8.5.25 not exempt)"]

    I["apps/store/package.json overrides"] --> J["brace-expansion: ^5.0.9"]
    J --> K["bun.lock: brace-expansion@5.0.9 ✓"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apnpm-workspace.yaml%3A42%0AThe%20%60minimumReleaseAgeExclude%60%20entry%20exempts%20%60postcss%408.5.23%60%2C%20but%20the%20override%20%60%5E8.5.23%60%20resolves%20to%20%60postcss%408.5.25%60%20in%20the%20lock%20file.%20Every%20other%20entry%20in%20this%20list%20%28%60brace-expansion%405.0.9%60%2C%20%60%40hono%2Fnode-server%402.0.5%60%2C%20etc.%29%20matches%20the%20exact%20version%20that%20lands%20in%20the%20lock%20file.%20If%20the%20minimum-release-age%20policy%20is%20active%2C%20a%20fresh%20%60pnpm%20install%60%20would%20check%20%608.5.25%60's%20age%2C%20not%20%608.5.23%60's%2C%20and%20could%20be%20blocked%20because%20%608.5.25%60%20isn't%20in%20the%20exemption%20list.%0A%0A%60%60%60suggestion%0A%20%20-%20postcss%408.5.25%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pnpm-workspace.yaml:42
The `minimumReleaseAgeExclude` entry exempts `postcss@8.5.23`, but the override `^8.5.23` resolves to `postcss@8.5.25` in the lock file. Every other entry in this list (`brace-expansion@5.0.9`, `@hono/node-server@2.0.5`, etc.) matches the exact version that lands in the lock file. If the minimum-release-age policy is active, a fresh `pnpm install` would check `8.5.25`'s age, not `8.5.23`'s, and could be blocked because `8.5.25` isn't in the exemption list.

```suggestion
  - postcss@8.5.25
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["security: bump brace-expansion/postcss o..."](https://github.com/gnt-ai/gnt/commit/3b8341443d826ffb364f99aba71f18120af7df22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49774149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->