### PR TITLE
Update README to remove terminal session image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ Run the setup below once and every agent your team runs has a **git-native ruleb
 
 > Prefer not to run any of this yourself? The hosted version at [gntai.dev](https://gntai.dev) does the same thing without you standing up a Postgres instance.
 
-![A real terminal session of gnt prebrain scanning a repo, opening a PR, and getting merged](.github/assets/quickstart.png)
-
-*gnt prebrain scanning a repo, opening a PR, and getting it merged. A real terminal session, not a mockup.*
-
 ## Get started (30 seconds)
 
 ```bash


### PR DESCRIPTION
Removed image and description of gnt prebrain terminal session from README.

## What & why



## Test plan



## Before you open this

Reviewers here hold PRs to the same bar the maintainers hold their own changes to. Check these
before requesting review, not after:

- [ ] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [ ] Functionally correct: you ran this, not just read it. If it touches `apps/api` or
      `apps/store`, you ran the relevant test suite locally.
- [ ] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left
      behind.
- [ ] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a
      test. A one-line change doesn't need one; a new code path does.
- [ ] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects
      org/tenant isolation — no query or check that could leak one org's data to another.
- [ ] Matches this repo's existing patterns rather than introducing a new one for the same
      problem — see `CONTRIBUTING.md`'s code conventions.
- [ ] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the
      recall/precision numbers from `bun run eval:extraction -- --mode cloud`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the quickstart terminal-session image and its caption from the README.
  * All setup instructions and remaining documentation are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the terminal session screenshot and its caption from the README, leaving the animated CLI demo GIF that follows the "Get started" section as the primary visual.

- Removes the `![A real terminal session…](.github/assets/quickstart.png)` image tag and its italic caption from the README preamble.
- The underlying image file (`.github/assets/quickstart.png`) still exists in the repository but is no longer referenced.

<h3>Confidence Score: 5/5</h3>

A two-line documentation removal with no code changes — safe to merge as-is.

The change removes a static image reference and its caption from the README. Nothing functional is touched, and the remaining GIF demo is still in place to illustrate the CLI workflow.

**Files Needing Attention:** No files require special attention. The orphaned `.github/assets/quickstart.png` can optionally be cleaned up in a follow-up, but it causes no harm.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Removes two lines (image embed and its italic caption) from the introductory section; no functional or structural issues. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Update README to remove terminal session..."](https://github.com/gnt-ai/gnt/commit/4e1fa37c766a855c807a6867d5c584511bf40a74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49935390)</sub>

<!-- /greptile_comment -->