### PR TITLE
zendesk: validate subdomain to close an SSRF hole

### DIFF
--- a/apps/api/src/gnt/routers/zendesk.py
+++ b/apps/api/src/gnt/routers/zendesk.py
@@ -1,5 +1,7 @@
+import re
+
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, SecretStr, field_validator
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,11 +17,24 @@ from gnt.zendesk_sync_status import get_sync_status
 
 router = APIRouter(prefix="/v1/settings/zendesk", tags=["zendesk"])
 
+_SUBDOMAIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", re.IGNORECASE)
+
 
 class ConnectZendeskRequest(BaseModel):
     subdomain: str
     agent_email: str
     api_token: SecretStr
+
+    @field_validator("subdomain")
+    @classmethod
+    def validate_subdomain(cls, value: str) -> str:
+        # Must be a bare DNS label -- no dots, slashes, or fragment/query
+        # characters -- so it can't redirect _base_url's host interpolation
+        # at an attacker-controlled host (e.g. cloud metadata via a value
+        # like "169.254.169.254/x#").
+        if not _SUBDOMAIN_RE.fullmatch(value.strip()):
+            raise ValueError("subdomain must be a valid Zendesk subdomain (letters, numbers, hyphens only)")
+        return value
 
 
 def _serialize(connection: ZendeskConnection) -> dict:

--- a/apps/api/src/gnt/zendesk/client.py
+++ b/apps/api/src/gnt/zendesk/client.py
@@ -23,6 +23,7 @@ self-serve in the customer's own Zendesk admin (Admin Center -> Apps and
 integrations -> APIs -> Zendesk API), no OAuth app review needed.
 """
 
+import re
 from dataclasses import dataclass
 from html import unescape
 from html.parser import HTMLParser
@@ -31,6 +32,14 @@ import httpx
 
 _REQUEST_TIMEOUT_SECONDS = 15.0
 
+# A bare DNS label -- no dots, slashes, or fragment/query characters --
+# so a value like "169.254.169.254/x#" can never turn "subdomain" into
+# an attacker-controlled host once "_base_url" appends ".zendesk.com".
+# Enforced again here (routers/zendesk.py validates on write) because
+# the nightly sync worker reads "subdomain" back out of the database and
+# calls this client directly, bypassing the request-model validator.
+_SUBDOMAIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", re.IGNORECASE)
+
 
 class ZendeskClientError(Exception):
     """Raised for anything other than a clean 2xx from Zendesk's API --
@@ -38,6 +47,8 @@ class ZendeskClientError(Exception):
 
 
 def _base_url(subdomain: str) -> str:
+    if not _SUBDOMAIN_RE.fullmatch(subdomain):
+        raise ZendeskClientError(f"invalid Zendesk subdomain: {subdomain!r}")
     return f"https://{subdomain}.zendesk.com/api/v2"
 
 


### PR DESCRIPTION
subdomain went straight from the connect request into the zendesk base URL with no format check. a value like `169.254.169.254/x#` parses as that host once `.zendesk.com` gets appended after the fragment, so an admin could point our outbound requests (including the nightly sync) at cloud metadata or any internal host.

now validated as a bare DNS label (letters/digits/hyphens only) at the request boundary and again defensively in the client itself, since the sync worker reads subdomain back out of the db and calls the client directly.

## test plan
- unit-tested the regex against the exploit payloads and legit subdomains
- ruff clean on both files
- matches the same fix already merged on the private repo, where the full pytest suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for Zendesk subdomains.
  * Leading and trailing spaces are removed before validation.
  * Subdomains must contain only letters, numbers, and hyphens.
  * Invalid subdomains now produce a clear validation error.
  * Prevented malformed Zendesk URLs from being created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes an SSRF vulnerability where a Zendesk subdomain value was interpolated directly into the base URL without validation, allowing a crafted value like `169.254.169.254/x#` to redirect outbound requests to cloud-metadata or internal hosts. Validation is applied at two layers to cover both the HTTP request path and the nightly sync worker's direct-to-client call.

- **Router layer** (`routers/zendesk.py`): a Pydantic `field_validator` runs `fullmatch` against a strict DNS-label regex (`[a-z0-9]`, hyphens in the middle, no dots/slashes/fragments), blocking invalid input with a clear 422 before any HTTP call is attempted.
- **Client layer** (`zendesk/client.py`): the same regex is enforced again inside `_base_url`, guarding the sync-worker path that reads the subdomain from the database and invokes the client directly, bypassing the request-model validator.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the SSRF fix is correctly implemented with no regressions introduced.

Both validation layers use `re.fullmatch` so the entire subdomain string must satisfy the DNS-label pattern. The regex correctly restricts first/last chars to alphanumeric, allows hyphens only in the interior, and preserves the 63-character DNS-label limit. The client-side guard in `_base_url` independently protects the sync-worker path that bypasses the request-model validator.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/gnt/routers/zendesk.py | Adds a Pydantic field_validator using fullmatch against a strict DNS-label regex to reject malformed subdomains at the request boundary before any HTTP call is made. |
| apps/api/src/gnt/zendesk/client.py | Adds a defensive fullmatch check in _base_url that guards the sync-worker path where subdomain arrives straight from the database, bypassing the request-layer validator. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin as Admin (HTTP)
    participant Router as routers/zendesk.py
    participant Pydantic as ConnectZendeskRequest validator
    participant Client as zendesk/client.py (_base_url)
    participant Zendesk as Zendesk API

    Admin->>Router: "POST /v1/settings/zendesk {subdomain, ...}"
    Router->>Pydantic: parse body
    Pydantic->>Pydantic: fullmatch(_SUBDOMAIN_RE, subdomain.strip())
    alt invalid subdomain
        Pydantic-->>Admin: 422 Validation Error
    else valid subdomain
        Pydantic-->>Router: body (validated)
        Router->>Client: verify_credentials(subdomain, ...)
        Client->>Client: "_base_url(subdomain) — fullmatch check #2"
        Client->>Zendesk: GET /users/me.json
        Zendesk-->>Client: 200 OK
        Client-->>Router: credentials verified
        Router->>Router: store to DB (stripped subdomain)
        Router-->>Admin: 201 Created
    end

    Note over Router,Client: Nightly sync worker path
    participant Sync as Sync Worker
    Sync->>Client: "verify_credentials / list_* (subdomain from DB)"
    Client->>Client: _base_url(subdomain) — fullmatch check
    alt DB value somehow invalid
        Client-->>Sync: ZendeskClientError
    else valid
        Client->>Zendesk: API request
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["zendesk: validate subdomain to close an ..."](https://github.com/gnt-ai/gnt/commit/3808040cdc49aec3a94da093897bc8bf18507b4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49936186)</sub>

<!-- /greptile_comment -->