### PR TITLE
test(cli): cover connect hermes and openclaw flows

### DIFF
--- a/apps/cli/test/connect-hermes.test.ts
+++ b/apps/cli/test/connect-hermes.test.ts
@@ -1,0 +1,250 @@
+// Tests `gnt connect hermes` (commands/connect-hermes.ts): the interactive
+// config-write flow that hermes-config.test.ts deliberately does not cover.
+// HERMES_DIR / HERMES_CONFIG_PATH are hardcoded to ~/.hermes at module load
+// (no GNT_CONFIG_DIR-style override), so this file mocks hermes-config.js's
+// path exports to a temp dir — same mock.module precedent connect-github
+// and org.test.ts already set for other frozen-at-import values.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as realReadline from "node:readline";
+
+const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-connect-hermes-creds-"));
+const fakeHome = mkdtempSync(join(tmpdir(), "gnt-connect-hermes-home-"));
+const hermesDir = join(fakeHome, ".hermes");
+const hermesConfigPath = join(hermesDir, "config.yaml");
+const previousConfigDir = process.env.GNT_CONFIG_DIR;
+process.env.GNT_CONFIG_DIR = testConfigDir;
+
+const realHermesConfig = await import("../src/hermes-config.js");
+mock.module("../src/hermes-config.js", () => ({
+  ...realHermesConfig,
+  HERMES_DIR: hermesDir,
+  HERMES_CONFIG_PATH: hermesConfigPath,
+}));
+
+let promptAnswers: string[] = [];
+let useReadlineMock = false;
+
+mock.module("node:readline", () => ({
+  ...realReadline,
+  createInterface: (opts: Parameters<typeof realReadline.createInterface>[0]) => {
+    if (!useReadlineMock) {
+      return realReadline.createInterface(opts);
+    }
+    return {
+      question: (_prompt: string, cb: (answer: string) => void) => {
+        cb(promptAnswers.shift() ?? "");
+      },
+      close: () => {},
+    };
+  },
+}));
+
+const { saveApiKey } = await import("../src/credentials.js");
+const { GNT_KEY_ENV_VAR } = await import("../src/hermes-config.js");
+const { connectHermes } = await import("../src/commands/connect-hermes.js");
+
+if (previousConfigDir === undefined) {
+  delete process.env.GNT_CONFIG_DIR;
+} else {
+  process.env.GNT_CONFIG_DIR = previousConfigDir;
+}
+
+// eslint-disable-next-line no-control-regex -- strips terminal ANSI color sequences before assertions.
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+let originalFetch: typeof fetch;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+let originalStdinIsTTY: boolean | undefined;
+let logs: string[];
+let errors: string[];
+let exitCalls: number[];
+
+function output(): string {
+  return stripAnsi(logs.join("\n"));
+}
+
+function errorOutput(): string {
+  return stripAnsi(errors.join("\n"));
+}
+
+function mockFetch(body: unknown, status = 200) {
+  const fetchMock = mock(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function cleanHermesHome(): void {
+  rmSync(hermesDir, { recursive: true, force: true });
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+  originalStdinIsTTY = process.stdin.isTTY;
+
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  saveApiKey("gnt_live_test_key", "key-id");
+  cleanHermesHome();
+
+  logs = [];
+  errors = [];
+  exitCalls = [];
+  promptAnswers = [];
+  useReadlineMock = true;
+
+  console.log = (...args: unknown[]) => {
+    logs.push(args.join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args.join(" "));
+  };
+  process.exit = ((code?: number | string) => {
+    exitCalls.push(Number(code));
+    throw new Error("process.exit called");
+  }) as unknown as typeof process.exit;
+
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+  Object.defineProperty(process.stdin, "isTTY", { value: originalStdinIsTTY, configurable: true });
+  useReadlineMock = false;
+  promptAnswers = [];
+  cleanHermesHome();
+  rmSync(join(testConfigDir, "credentials.json"), { force: true });
+
+  if (previousConfigDir === undefined) {
+    delete process.env.GNT_CONFIG_DIR;
+  } else {
+    process.env.GNT_CONFIG_DIR = previousConfigDir;
+  }
+});
+
+test("exits when ~/.hermes is missing, without creating anything under the fake home", async () => {
+  await expect(connectHermes()).rejects.toThrow("process.exit called");
+
+  expect(exitCalls).toEqual([1]);
+  expect(errorOutput()).toContain("No local Hermes install found");
+  expect(errorOutput()).toContain("https://hermes-agent.nousresearch.com/docs/getting-started/installation");
+  expect(existsSync(hermesDir)).toBe(false);
+  expect(existsSync(join(fakeHome, ".hermes"))).toBe(false);
+});
+
+test("short-circuits when mcp_servers.gnt already exists, leaving the file and no .bak", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  const existing = ['mcp_servers:', '  gnt:', '    url: "https://example.com/mcp"', ""].join("\n");
+  writeFileSync(hermesConfigPath, existing);
+
+  await connectHermes();
+
+  expect(output()).toContain("already configured");
+  expect(output()).toContain("mcp_servers.gnt");
+  expect(readFileSync(hermesConfigPath, "utf-8")).toBe(existing);
+  expect(existsSync(`${hermesConfigPath}.bak`)).toBe(false);
+});
+
+test("declined consent prints Nothing written and leaves a present config untouched", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  const existing = 'model:\n  name: "x"\n';
+  writeFileSync(hermesConfigPath, existing);
+  promptAnswers = ["n"];
+
+  await connectHermes();
+
+  expect(output()).toContain("Nothing written");
+  expect(readFileSync(hermesConfigPath, "utf-8")).toBe(existing);
+  expect(existsSync(`${hermesConfigPath}.bak`)).toBe(false);
+});
+
+test("declined consent with no config file yet still writes nothing", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  promptAnswers = ["no"];
+
+  await connectHermes();
+
+  expect(output()).toContain("Nothing written");
+  expect(existsSync(hermesConfigPath)).toBe(false);
+});
+
+test("fresh install: consent + successful mint writes config, no .bak, prints the key and export hint", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  promptAnswers = ["y"];
+  mockFetch({ key: "gnt_mcp_minted_abc" });
+
+  await connectHermes();
+
+  expect(existsSync(hermesConfigPath)).toBe(true);
+  expect(existsSync(`${hermesConfigPath}.bak`)).toBe(false);
+  const written = readFileSync(hermesConfigPath, "utf-8");
+  expect(written).toContain("mcp_servers:");
+  expect(written).toContain("  gnt:");
+  expect(written).toContain(`\${${GNT_KEY_ENV_VAR}}`);
+  expect(output()).toContain("Connected");
+  expect(output()).toContain("gnt_mcp_minted_abc");
+  expect(output()).toContain(`Export ${GNT_KEY_ENV_VAR}=gnt_mcp_minted_abc`);
+});
+
+test("existing config without gnt: consent writes a .bak with the original content", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  const existing = 'model:\n  name: "kept"\n';
+  writeFileSync(hermesConfigPath, existing);
+  promptAnswers = ["yes"];
+  mockFetch({ key: "gnt_mcp_minted_xyz" });
+
+  await connectHermes();
+
+  expect(existsSync(`${hermesConfigPath}.bak`)).toBe(true);
+  expect(readFileSync(`${hermesConfigPath}.bak`, "utf-8")).toBe(existing);
+  const written = readFileSync(hermesConfigPath, "utf-8");
+  expect(written).toContain('name: "kept"');
+  expect(written).toContain("  gnt:");
+  expect(output()).toContain("backup of the previous config");
+});
+
+test("mintKey network failure still leaves the written config and falls back to gnt keys create hint", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  promptAnswers = ["y"];
+  globalThis.fetch = mock(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+
+  await connectHermes();
+
+  expect(existsSync(hermesConfigPath)).toBe(true);
+  expect(readFileSync(hermesConfigPath, "utf-8")).toContain("  gnt:");
+  expect(output()).toContain("Couldn't reach");
+  expect(output()).toContain("Run `gnt keys create`");
+  expect(output()).not.toContain("MCP key:");
+});
+
+test("mintKey non-ok response still leaves the written config and falls back to gnt keys create hint", async () => {
+  mkdirSync(hermesDir, { recursive: true });
+  promptAnswers = ["y"];
+  mockFetch({ detail: "nope" }, 500);
+
+  await connectHermes();
+
+  expect(existsSync(hermesConfigPath)).toBe(true);
+  expect(output()).toContain("Couldn't mint an MCP key (500)");
+  expect(output()).toContain("Run `gnt keys create`");
+});

--- a/apps/cli/test/connect-hermes.test.ts
+++ b/apps/cli/test/connect-hermes.test.ts
@@ -95,6 +95,8 @@ function cleanHermesHome(): void {
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
+  // Reject by default so paths that shouldn't mint can't leak a real network call.
+  globalThis.fetch = mock(() => Promise.reject(new Error("Unexpected fetch"))) as unknown as typeof fetch;
   originalLog = console.log;
   originalError = console.error;
   originalExit = process.exit;
@@ -133,13 +135,23 @@ afterEach(() => {
   useReadlineMock = false;
   promptAnswers = [];
   cleanHermesHome();
-  rmSync(join(testConfigDir, "credentials.json"), { force: true });
+  rmSync(testConfigDir, { recursive: true, force: true });
 
   if (previousConfigDir === undefined) {
     delete process.env.GNT_CONFIG_DIR;
   } else {
     process.env.GNT_CONFIG_DIR = previousConfigDir;
   }
+});
+
+test("exits when not logged in, before touching the hermes home", async () => {
+  rmSync(join(testConfigDir, "credentials.json"), { force: true });
+
+  await expect(connectHermes()).rejects.toThrow("process.exit called");
+
+  expect(exitCalls).toEqual([1]);
+  expect(errorOutput()).toContain("Not logged in");
+  expect(existsSync(hermesDir)).toBe(false);
 });
 
 test("exits when ~/.hermes is missing, without creating anything under the fake home", async () => {
@@ -151,7 +163,6 @@ test("exits when ~/.hermes is missing, without creating anything under the fake 
   expect(existsSync(hermesDir)).toBe(false);
   expect(existsSync(join(fakeHome, ".hermes"))).toBe(false);
 });
-
 test("short-circuits when mcp_servers.gnt already exists, leaving the file and no .bak", async () => {
   mkdirSync(hermesDir, { recursive: true });
   const existing = ['mcp_servers:', '  gnt:', '    url: "https://example.com/mcp"', ""].join("\n");

--- a/apps/cli/test/connect-openclaw.test.ts
+++ b/apps/cli/test/connect-openclaw.test.ts
@@ -134,6 +134,8 @@ function writeOpenclawConfig(value: unknown): void {
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
+  // Reject by default so paths that shouldn't mint can't leak a real network call.
+  globalThis.fetch = mock(() => Promise.reject(new Error("Unexpected fetch"))) as unknown as typeof fetch;
   originalLog = console.log;
   originalError = console.error;
   originalExit = process.exit;
@@ -170,7 +172,7 @@ afterEach(() => {
   useReadlineMock = false;
   promptAnswers = [];
   cleanOpenclawHome();
-  rmSync(join(testConfigDir, "credentials.json"), { force: true });
+  rmSync(testConfigDir, { recursive: true, force: true });
 
   if (previousConfigDir === undefined) {
     delete process.env.GNT_CONFIG_DIR;
@@ -221,6 +223,7 @@ test("existing gnt-brain entry reports already configured and does not write", a
 
 test("no local credentials: mintKey returns without prompting or fetch; falls through to existing-key ask", async () => {
   writeOpenclawConfig({ other: true });
+  const before = readFileSync(openclawConfigPath, "utf-8");
   rmSync(join(testConfigDir, "credentials.json"), { force: true });
   // Decline "already have a key?" then decline the final write confirm.
   // Both prompts go through readline (not console.log), so we assert on
@@ -233,7 +236,8 @@ test("no local credentials: mintKey returns without prompting or fetch; falls th
   expect(liveValidationCalls).toBe(0);
   expect(output()).toContain("Found an OpenClaw install");
   expect(output()).toContain("Nothing written");
-  expect(JSON.parse(readFileSync(openclawConfigPath, "utf-8"))).toEqual({ other: true });
+  // Raw bytes, not parsed equality — a rewrite of equivalent JSON would still fail.
+  expect(readFileSync(openclawConfigPath, "utf-8")).toBe(before);
 });
 
 test("happy path: mint + live validate + write merges gnt-brain and prints the minted success hint", async () => {
@@ -272,6 +276,7 @@ test("happy path: mint + live validate + write merges gnt-brain and prints the m
 
 test("live validation failure writes nothing and prints the manual block", async () => {
   writeOpenclawConfig({ mcp: { servers: {} } });
+  const before = readFileSync(openclawConfigPath, "utf-8");
   promptAnswers = ["y"];
   mockFetch({ key: "gnt_mcp_bad" });
   liveValidationShouldFail = true;
@@ -282,12 +287,12 @@ test("live validation failure writes nothing and prints the manual block", async
   expect(errorOutput()).toContain("Couldn't reach gnt's MCP endpoint");
   expect(output()).toContain("Nothing written");
   expect(output()).toContain("gnt-brain");
-  const written = JSON.parse(readFileSync(openclawConfigPath, "utf-8"));
-  expect(written).toEqual({ mcp: { servers: {} } });
+  expect(readFileSync(openclawConfigPath, "utf-8")).toBe(before);
 });
 
 test("final write declined prints Nothing written even after a successful mint and validate", async () => {
   writeOpenclawConfig({ mcp: { servers: {} } });
+  const before = readFileSync(openclawConfigPath, "utf-8");
   // mint confirm, final write decline
   promptAnswers = ["y", "n"];
   mockFetch({ key: "gnt_mcp_unused" });
@@ -297,5 +302,5 @@ test("final write declined prints Nothing written even after a successful mint a
   expect(liveValidationCalls).toBe(1);
   expect(output()).toContain("Connected to gnt's MCP endpoint");
   expect(output()).toContain("Nothing written");
-  expect(JSON.parse(readFileSync(openclawConfigPath, "utf-8"))).toEqual({ mcp: { servers: {} } });
+  expect(readFileSync(openclawConfigPath, "utf-8")).toBe(before);
 });

--- a/apps/cli/test/connect-openclaw.test.ts
+++ b/apps/cli/test/connect-openclaw.test.ts
@@ -1,0 +1,301 @@
+// Tests `gnt connect openclaw` (commands/connect-openclaw.ts): consent,
+// mint, live-validate, and write paths against a third-party config file.
+// OPENCLAW_CONFIG_PATH is frozen to join(homedir(), ".openclaw/openclaw.json")
+// at module load, so this file mocks node:os.homedir to a temp dir for that
+// import only (then restores real homedir for the rest of the bun test
+// process). The MCP SDK client/transport are also mocked — first time this
+// repo's suite has done that.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import * as realOs from "node:os";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as realReadline from "node:readline";
+
+const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-connect-openclaw-creds-"));
+const fakeHome = mkdtempSync(join(tmpdir(), "gnt-connect-openclaw-home-"));
+const openclawDir = join(fakeHome, ".openclaw");
+const openclawConfigPath = join(openclawDir, "openclaw.json");
+const previousConfigDir = process.env.GNT_CONFIG_DIR;
+process.env.GNT_CONFIG_DIR = testConfigDir;
+
+// Bake OPENCLAW_CONFIG_PATH against fakeHome at connect-openclaw import time,
+// then flip this off so later-loaded modules still see the real homedir.
+let useFakeHomedir = true;
+mock.module("node:os", () => ({
+  ...realOs,
+  homedir: () => (useFakeHomedir ? fakeHome : realOs.homedir()),
+}));
+
+let promptAnswers: string[] = [];
+let useReadlineMock = false;
+
+mock.module("node:readline", () => ({
+  ...realReadline,
+  createInterface: (opts: Parameters<typeof realReadline.createInterface>[0]) => {
+    if (!useReadlineMock) {
+      return realReadline.createInterface(opts);
+    }
+    return {
+      question: (_prompt: string, cb: (answer: string) => void) => {
+        cb(promptAnswers.shift() ?? "");
+      },
+      close: () => {},
+    };
+  },
+}));
+
+let liveValidationShouldFail = false;
+let liveValidationCalls = 0;
+
+mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class {
+    async connect() {
+      liveValidationCalls += 1;
+      if (liveValidationShouldFail) {
+        throw new Error("connection refused");
+      }
+    }
+    async listTools() {
+      if (liveValidationShouldFail) {
+        throw new Error("connection refused");
+      }
+      return { tools: [] };
+    }
+    async close() {}
+  },
+}));
+
+mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: class {
+    constructor(..._args: unknown[]) {
+      void _args;
+    }
+  },
+}));
+const { saveApiKey } = await import("../src/credentials.js");
+const { MCP_URL } = await import("../src/config.js");
+const { connectOpenclaw } = await import("../src/commands/connect-openclaw.js");
+
+// Path is baked into the command module now — restore real homedir for peers.
+useFakeHomedir = false;
+
+if (previousConfigDir === undefined) {
+  delete process.env.GNT_CONFIG_DIR;
+} else {
+  process.env.GNT_CONFIG_DIR = previousConfigDir;
+}
+
+// eslint-disable-next-line no-control-regex -- strips terminal ANSI color sequences before assertions.
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+let originalFetch: typeof fetch;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+let logs: string[];
+let errors: string[];
+let fetchCalls: Array<{ input: string; init?: RequestInit }>;
+
+function output(): string {
+  return stripAnsi(logs.join("\n"));
+}
+
+function errorOutput(): string {
+  return stripAnsi(errors.join("\n"));
+}
+
+function mockFetch(body: unknown, status = 200) {
+  const fetchMock = mock((input: string | URL | Request, init?: RequestInit) => {
+    fetchCalls.push({ input: String(input), init });
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function cleanOpenclawHome(): void {
+  rmSync(openclawDir, { recursive: true, force: true });
+}
+
+function writeOpenclawConfig(value: unknown): void {
+  mkdirSync(openclawDir, { recursive: true });
+  writeFileSync(openclawConfigPath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  // Default: logged in. Individual tests clear credentials when needed.
+  saveApiKey("gnt_live_test_key", "key-id");
+  cleanOpenclawHome();
+
+  logs = [];
+  errors = [];
+  fetchCalls = [];
+  promptAnswers = [];
+  useReadlineMock = true;
+  liveValidationShouldFail = false;
+  liveValidationCalls = 0;
+
+  console.log = (...args: unknown[]) => {
+    logs.push(args.join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args.join(" "));
+  };
+  process.exit = ((code?: number | string) => {
+    throw new Error(`process.exit called with ${code}`);
+  }) as unknown as typeof process.exit;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+  useReadlineMock = false;
+  promptAnswers = [];
+  cleanOpenclawHome();
+  rmSync(join(testConfigDir, "credentials.json"), { force: true });
+
+  if (previousConfigDir === undefined) {
+    delete process.env.GNT_CONFIG_DIR;
+  } else {
+    process.env.GNT_CONFIG_DIR = previousConfigDir;
+  }
+});
+
+test("missing config prints the manual JSON block and writes nothing", async () => {
+  await connectOpenclaw();
+
+  expect(output()).toContain("No local OpenClaw install detected");
+  expect(output()).toContain("gnt-brain");
+  expect(output()).toContain(MCP_URL);
+  expect(output()).toContain("mcp");
+  expect(existsSync(openclawConfigPath)).toBe(false);
+});
+
+test("malformed JSON falls back to the manual block and leaves the broken file untouched", async () => {
+  mkdirSync(openclawDir, { recursive: true });
+  const broken = '{\n  // comment\n  "mcp": {}\n}\n';
+  writeFileSync(openclawConfigPath, broken);
+
+  await connectOpenclaw();
+
+  expect(output()).toContain("isn't strict JSON");
+  expect(output()).toContain("gnt-brain");
+  expect(readFileSync(openclawConfigPath, "utf-8")).toBe(broken);
+});
+
+test("existing gnt-brain entry reports already configured and does not write", async () => {
+  writeOpenclawConfig({
+    mcp: {
+      servers: {
+        "gnt-brain": { url: "https://example.com/mcp/" },
+      },
+    },
+  });
+  const before = readFileSync(openclawConfigPath, "utf-8");
+
+  await connectOpenclaw();
+
+  expect(output()).toContain("already configured");
+  expect(output()).toContain("gnt-brain");
+  expect(readFileSync(openclawConfigPath, "utf-8")).toBe(before);
+  expect(fetchCalls).toHaveLength(0);
+});
+
+test("no local credentials: mintKey returns without prompting or fetch; falls through to existing-key ask", async () => {
+  writeOpenclawConfig({ other: true });
+  rmSync(join(testConfigDir, "credentials.json"), { force: true });
+  // Decline "already have a key?" then decline the final write confirm.
+  // Both prompts go through readline (not console.log), so we assert on
+  // the no-fetch + unchanged-file side effects rather than the prompt text.
+  promptAnswers = ["n", "n"];
+
+  await connectOpenclaw();
+
+  expect(fetchCalls).toHaveLength(0);
+  expect(liveValidationCalls).toBe(0);
+  expect(output()).toContain("Found an OpenClaw install");
+  expect(output()).toContain("Nothing written");
+  expect(JSON.parse(readFileSync(openclawConfigPath, "utf-8"))).toEqual({ other: true });
+});
+
+test("happy path: mint + live validate + write merges gnt-brain and prints the minted success hint", async () => {
+  writeOpenclawConfig({
+    gateway: { port: 18789 },
+    mcp: { servers: { other: { url: "https://other.example/" } } },
+  });
+  // mint confirm, final write confirm
+  promptAnswers = ["y", "y"];
+  mockFetch({ key: "gnt_mcp_openclaw_1" });
+
+  await connectOpenclaw();
+
+  expect(liveValidationCalls).toBe(1);
+  expect(fetchCalls).toHaveLength(1);
+  expect(String(fetchCalls[0]?.input)).toContain("/v1/settings/mcp-keys");
+  expect(fetchCalls[0]?.init?.body).toBe(JSON.stringify({ name: "openclaw" }));
+
+  const written = JSON.parse(readFileSync(openclawConfigPath, "utf-8")) as {
+    gateway: { port: number };
+    mcp: { servers: Record<string, { url: string; transport: string; headers: { Authorization: string } }> };
+  };
+  expect(written.gateway.port).toBe(18789);
+  expect(written.mcp.servers.other).toEqual({ url: "https://other.example/" });
+  expect(written.mcp.servers["gnt-brain"]).toEqual({
+    url: MCP_URL,
+    transport: "streamable-http",
+    headers: { Authorization: "Bearer ${GNT_MCP_KEY}" },
+  });
+
+  expect(output()).toContain("Minted an MCP key");
+  expect(output()).toContain("gnt_mcp_openclaw_1");
+  expect(output()).toContain('Added "gnt-brain"');
+  expect(output()).toContain("Export GNT_MCP_KEY=<the key printed above>");
+});
+
+test("live validation failure writes nothing and prints the manual block", async () => {
+  writeOpenclawConfig({ mcp: { servers: {} } });
+  promptAnswers = ["y"];
+  mockFetch({ key: "gnt_mcp_bad" });
+  liveValidationShouldFail = true;
+
+  await connectOpenclaw();
+
+  expect(liveValidationCalls).toBe(1);
+  expect(errorOutput()).toContain("Couldn't reach gnt's MCP endpoint");
+  expect(output()).toContain("Nothing written");
+  expect(output()).toContain("gnt-brain");
+  const written = JSON.parse(readFileSync(openclawConfigPath, "utf-8"));
+  expect(written).toEqual({ mcp: { servers: {} } });
+});
+
+test("final write declined prints Nothing written even after a successful mint and validate", async () => {
+  writeOpenclawConfig({ mcp: { servers: {} } });
+  // mint confirm, final write decline
+  promptAnswers = ["y", "n"];
+  mockFetch({ key: "gnt_mcp_unused" });
+
+  await connectOpenclaw();
+
+  expect(liveValidationCalls).toBe(1);
+  expect(output()).toContain("Connected to gnt's MCP endpoint");
+  expect(output()).toContain("Nothing written");
+  expect(JSON.parse(readFileSync(openclawConfigPath, "utf-8"))).toEqual({ mcp: { servers: {} } });
+});


### PR DESCRIPTION
## What & why

Adds test coverage for the two MCP-out connect commands that edit third-party config files — `gnt connect hermes` (#15) and `gnt connect openclaw` (#16). The pure text-patching logic for Hermes was already covered; these tests pin the consent, mint, backup/write, and (for OpenClaw) live-validation paths that previously had no coverage.

- `apps/cli/test/connect-hermes.test.ts` — missing install, already configured, declined consent, fresh mint, `.bak` on existing config, mint network/non-ok fallbacks
- `apps/cli/test/connect-openclaw.test.ts` — missing/malformed config, already configured, no local credentials, happy path (mint + live validate + write), live-validation failure, declined final write

Hermes paths are overridden via `mock.module` on `hermes-config.js` (same frozen-at-import pattern as `org.test.ts`). OpenClaw bakes `OPENCLAW_CONFIG_PATH` against a temp `homedir` at import, and mocks the MCP SDK client/transport for the live handshake.

Closes #15
Closes #16

## Test plan

- [x] `cd apps/cli && bun test connect-hermes.test.ts connect-openclaw.test.ts`
- [x] `cd apps/cli && bun test` (full suite)
- [x] `pnpm turbo run lint typecheck build test --filter=@gnt-ai/cli`

```
bun test connect-hermes.test.ts connect-openclaw.test.ts
bun test v1.3.11 (af24e281)

test/connect-hermes.test.ts:
(pass) exits when ~/.hermes is missing, without creating anything under the fake home
(pass) short-circuits when mcp_servers.gnt already exists, leaving the file and no .bak
(pass) declined consent prints Nothing written and leaves a present config untouched
(pass) declined consent with no config file yet still writes nothing
(pass) fresh install: consent + successful mint writes config, no .bak, prints the key and export hint
(pass) existing config without gnt: consent writes a .bak with the original content
(pass) mintKey network failure still leaves the written config and falls back to gnt keys create hint
(pass) mintKey non-ok response still leaves the written config and falls back to gnt keys create hint

test/connect-openclaw.test.ts:
(pass) missing config prints the manual JSON block and writes nothing
(pass) malformed JSON falls back to the manual block and leaves the broken file untouched
(pass) existing gnt-brain entry reports already configured and does not write
(pass) no local credentials: mintKey returns without prompting or fetch; falls through to existing-key ask
(pass) happy path: mint + live validate + write merges gnt-brain and prints the minted success hint
(pass) live validation failure writes nothing and prints the manual block
(pass) final write declined prints Nothing written even after a successful mint and validate

 15 pass
 0 fail
Ran 15 tests across 2 files.
```

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or
      `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left
      behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a
      test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects
      org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same
      problem — see `CONTRIBUTING.md`'s code conventions.
- [x] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the
      recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for connecting to Hermes and OpenClaw.
  * Verified handling of missing or invalid configurations, existing setups, declined consent, credential issues, and network failures.
  * Tested successful credential creation, configuration backups, file writes, and live connection validation.
  * Improved confidence in connection setup reliability across successful and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds test coverage for `gnt connect hermes` and `gnt connect openclaw` — the two commands that edit third-party config files on behalf of the user. No production code is changed; the two new test files exercise consent, mint, backup/write, live-validation, and early-exit paths.

- `connect-hermes.test.ts` covers 8 scenarios: missing hermes install, missing login, already-configured, declined consent (with and without an existing config), fresh mint, backup-on-overwrite, and mint network/non-ok fallbacks.
- `connect-openclaw.test.ts` covers 7 scenarios: missing/malformed config, already-configured, no local credentials, happy path (mint + live-validate + write), live-validation failure, and declined final write. It introduces the repo's first MCP SDK client/transport mock.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only test files are added, no production code changes.

Both files are purely additive test coverage. The mock strategies (frozen-at-import path overrides, readline queue, MCP SDK stubs) follow patterns already established in the repo and are correctly scoped. Each scenario exercises the right code paths. The only rough edges are minor temp-directory cleanup omissions that have no effect on correctness or CI reliability.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/test/connect-hermes.test.ts | New test file covering 8 hermes connect scenarios including the newly-added "not logged in" early-exit case. afterEach correctly removes testConfigDir. fakeHome is leaked (one temp dir per test run). |
| apps/cli/test/connect-openclaw.test.ts | New test file covering 7 openclaw connect scenarios including MCP SDK mocking. afterEach removes testConfigDir. fakeHome is leaked (one temp dir per test run). |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph H["connect-hermes.test.ts (8 tests)"]
        H1["not logged in → exit 1"]
        H2["~/.hermes missing → exit 1"]
        H3["mcp_servers.gnt exists → already configured"]
        H4["declined consent (config present)"]
        H5["declined consent (no config)"]
        H6["fresh mint → write config + key"]
        H7["existing config + consent → .bak + write"]
        H8["mint network/non-ok failure → write config + fallback hint"]
    end

    subgraph O["connect-openclaw.test.ts (7 tests)"]
        O1["config missing → manual block"]
        O2["malformed JSON → manual block"]
        O3["gnt-brain exists → already configured"]
        O4["no credentials → skip mint, decline prompts"]
        O5["happy path → mint + validate + write"]
        O6["live validate fails → nothing written"]
        O7["final write declined → nothing written"]
    end

    subgraph M["Module-level mocks"]
        M1["hermes-config.js → fakeHome paths"]
        M2["node:os homedir → fakeHome (import only)"]
        M3["node:readline → promptAnswers queue"]
        M4["@mcp/sdk Client + Transport → liveValidationCalls counter"]
    end

    M1 --> H
    M2 --> O
    M3 --> H & O
    M4 --> O
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): tighten connect hermes/opencl..."](https://github.com/gnt-ai/gnt/commit/951068fcfac1370ea8797fed59c466b9ebdae096) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50007084)</sub>

<!-- /greptile_comment -->