### PR TITLE
Add tests for slack connect command

### DIFF
--- a/apps/cli/test/connect-slack.test.ts
+++ b/apps/cli/test/connect-slack.test.ts
@@ -1,0 +1,156 @@
+// Tests `gnt connect slack` against mocked fetch/open — same shape as
+// connect-github.test.ts (install URL → open browser → poll until connected).
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-connect-slack-test-"));
+process.env.GNT_CONFIG_DIR = testConfigDir;
+
+let openShouldThrow = false;
+const openMock = mock(() => {
+  if (openShouldThrow) return Promise.reject(new Error("no browser"));
+  return Promise.resolve();
+});
+mock.module("open", () => ({ default: openMock }));
+
+const { saveApiKey } = await import("../src/credentials.js");
+const { connectSlack } = await import("../src/commands/connect-slack.js");
+
+const INSTALL_URL = "https://slack.com/oauth/v2/authorize?state=abc";
+
+let originalFetch: typeof fetch;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+let originalWrite: typeof process.stdout.write;
+let originalDateNow: typeof Date.now;
+let logs: string[];
+let errors: string[];
+let written: string[];
+let exitCalls: number[];
+
+// eslint-disable-next-line no-control-regex -- strips terminal ANSI color sequences before assertions.
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+beforeEach(() => {
+  saveApiKey("gnt_live_test_key", "11111111-1111-1111-1111-111111111111");
+  originalFetch = globalThis.fetch;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+  originalWrite = process.stdout.write;
+  originalDateNow = Date.now;
+  logs = [];
+  errors = [];
+  written = [];
+  exitCalls = [];
+  openShouldThrow = false;
+  openMock.mockClear();
+
+  console.log = mock((...args: unknown[]) => {
+    logs.push(args.join(" "));
+  });
+  console.error = mock((...args: unknown[]) => {
+    errors.push(args.join(" "));
+  });
+  process.exit = mock((code?: number) => {
+    exitCalls.push(code ?? 0);
+    throw new Error("process.exit called");
+  }) as unknown as typeof process.exit;
+  // spinner() writes straight to process.stdout in non-TTY mode (bun test).
+  process.stdout.write = mock((chunk: string) => {
+    written.push(chunk);
+    return true;
+  }) as unknown as typeof process.stdout.write;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+  process.stdout.write = originalWrite;
+  Date.now = originalDateNow;
+  rmSync(testConfigDir, { recursive: true, force: true });
+});
+
+test("exits non-zero when the install-url call fails", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(new Response(JSON.stringify({ detail: "slack not configured" }), { status: 502 })),
+  ) as unknown as typeof fetch;
+
+  await expect(connectSlack()).rejects.toThrow("process.exit called");
+
+  expect(exitCalls).toEqual([1]);
+  expect(stripAnsi(errors.join("\n"))).toContain("Failed to start Slack connect (502)");
+  expect(openMock).not.toHaveBeenCalled();
+});
+
+test("opens the install URL and reports success once slack_connected shows up on poll", async () => {
+  let pollCount = 0;
+  globalThis.fetch = mock((url: string) => {
+    if (String(url).includes("/v1/slack/install-url")) {
+      return Promise.resolve(new Response(JSON.stringify({ url: INSTALL_URL }), { status: 200 }));
+    }
+    // GET /v1/brain/summary — not connected the first call, connected the second.
+    pollCount += 1;
+    const body = pollCount === 1 ? { slack_connected: false } : { slack_connected: true };
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  }) as unknown as typeof fetch;
+
+  await connectSlack();
+
+  expect(stripAnsi(logs.join("\n"))).toContain(INSTALL_URL);
+  expect(openMock).toHaveBeenCalledWith(INSTALL_URL);
+  expect(stripAnsi(written.join(""))).toContain("Slack connected.");
+  expect(exitCalls).toHaveLength(0);
+});
+
+test("falls back to a manual-open message when open() throws, then still polls to success", async () => {
+  openShouldThrow = true;
+  let pollCount = 0;
+  globalThis.fetch = mock((url: string) => {
+    if (String(url).includes("/v1/slack/install-url")) {
+      return Promise.resolve(new Response(JSON.stringify({ url: INSTALL_URL }), { status: 200 }));
+    }
+    pollCount += 1;
+    const body = pollCount === 1 ? { slack_connected: false } : { slack_connected: true };
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  }) as unknown as typeof fetch;
+
+  await connectSlack();
+
+  expect(stripAnsi(logs.join("\n"))).toContain("Couldn't open a browser automatically");
+  expect(stripAnsi(written.join(""))).toContain("Slack connected.");
+  expect(exitCalls).toHaveLength(0);
+});
+
+test("timeout path prints Still waiting and does not call process.exit", async () => {
+  // Advance Date.now past the 5-minute deadline after the first poll so we
+  // don't literally wait out POLL_TIMEOUT_MS — one real POLL_INTERVAL_MS sleep
+  // is enough to enter the loop body once.
+  let now = 0;
+  Date.now = () => now;
+
+  globalThis.fetch = mock((url: string) => {
+    if (String(url).includes("/v1/slack/install-url")) {
+      return Promise.resolve(new Response(JSON.stringify({ url: INSTALL_URL }), { status: 200 }));
+    }
+    // After this poll returns, the next while-condition Date.now() check
+    // must see a time past the deadline (Date.now() at start + 5 minutes).
+    now = 5 * 60 * 1000 + 1;
+    return Promise.resolve(new Response(JSON.stringify({ slack_connected: false }), { status: 200 }));
+  }) as unknown as typeof fetch;
+
+  await connectSlack();
+
+  expect(stripAnsi(written.join(""))).toContain("Still waiting");
+  expect(stripAnsi(written.join(""))).toContain("gnt status");
+  expect(exitCalls).toHaveLength(0);
+});

--- a/apps/cli/test/connect-slack.test.ts
+++ b/apps/cli/test/connect-slack.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-connect-slack-test-"));
+const previousConfigDir = process.env.GNT_CONFIG_DIR;
 process.env.GNT_CONFIG_DIR = testConfigDir;
 
 let openShouldThrow = false;
@@ -18,6 +19,14 @@ mock.module("open", () => ({ default: openMock }));
 const { saveApiKey } = await import("../src/credentials.js");
 const { connectSlack } = await import("../src/commands/connect-slack.js");
 
+// Bun loads all test files into one process — don't leave our override set
+// for whatever file runs next.
+if (previousConfigDir === undefined) {
+  delete process.env.GNT_CONFIG_DIR;
+} else {
+  process.env.GNT_CONFIG_DIR = previousConfigDir;
+}
+
 const INSTALL_URL = "https://slack.com/oauth/v2/authorize?state=abc";
 
 let originalFetch: typeof fetch;
@@ -26,6 +35,7 @@ let originalError: typeof console.error;
 let originalExit: typeof process.exit;
 let originalWrite: typeof process.stdout.write;
 let originalDateNow: typeof Date.now;
+let originalSetTimeout: typeof setTimeout;
 let logs: string[];
 let errors: string[];
 let written: string[];
@@ -39,6 +49,7 @@ function stripAnsi(s: string): string {
 }
 
 beforeEach(() => {
+  process.env.GNT_CONFIG_DIR = testConfigDir;
   saveApiKey("gnt_live_test_key", "11111111-1111-1111-1111-111111111111");
   originalFetch = globalThis.fetch;
   originalLog = console.log;
@@ -46,12 +57,18 @@ beforeEach(() => {
   originalExit = process.exit;
   originalWrite = process.stdout.write;
   originalDateNow = Date.now;
+  originalSetTimeout = globalThis.setTimeout;
   logs = [];
   errors = [];
   written = [];
   exitCalls = [];
   openShouldThrow = false;
   openMock.mockClear();
+
+  // Collapse the 2s poll sleeps so two-poll paths don't burn ~4s each.
+  globalThis.setTimeout = ((handler: TimerHandler, _ms?: number, ...args: unknown[]) => {
+    return originalSetTimeout(handler as (...a: unknown[]) => void, 0, ...args);
+  }) as typeof setTimeout;
 
   console.log = mock((...args: unknown[]) => {
     logs.push(args.join(" "));
@@ -77,7 +94,14 @@ afterEach(() => {
   process.exit = originalExit;
   process.stdout.write = originalWrite;
   Date.now = originalDateNow;
+  globalThis.setTimeout = originalSetTimeout;
   rmSync(testConfigDir, { recursive: true, force: true });
+
+  if (previousConfigDir === undefined) {
+    delete process.env.GNT_CONFIG_DIR;
+  } else {
+    process.env.GNT_CONFIG_DIR = previousConfigDir;
+  }
 });
 
 test("exits non-zero when the install-url call fails", async () => {
@@ -126,6 +150,7 @@ test("falls back to a manual-open message when open() throws, then still polls t
 
   await connectSlack();
 
+  expect(openMock).toHaveBeenCalledWith(INSTALL_URL);
   expect(stripAnsi(logs.join("\n"))).toContain("Couldn't open a browser automatically");
   expect(stripAnsi(written.join(""))).toContain("Slack connected.");
   expect(exitCalls).toHaveLength(0);
@@ -133,8 +158,8 @@ test("falls back to a manual-open message when open() throws, then still polls t
 
 test("timeout path prints Still waiting and does not call process.exit", async () => {
   // Advance Date.now past the 5-minute deadline after the first poll so we
-  // don't literally wait out POLL_TIMEOUT_MS — one real POLL_INTERVAL_MS sleep
-  // is enough to enter the loop body once.
+  // don't literally wait out POLL_TIMEOUT_MS. setTimeout is already collapsed
+  // to 0ms in beforeEach.
   let now = 0;
   Date.now = () => now;
 


### PR DESCRIPTION
Hey — took issue #14.

Added `apps/cli/test/connect-slack.test.ts` with the cases from the issue (failed install url, happy path poll, browser open failing, and timeout). Followed the connect-github test for the mocking stuff.

```
cd apps/cli && bun test connect-slack.test.ts
```
all 4 passed on my machine.

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for Slack connection flows, including installation failures, browser-opening behavior, fallback handling, polling, timeouts, and configuration cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `apps/cli/test/connect-slack.test.ts` with four test cases covering the `connectSlack()` command: install-URL failure, happy-path poll-to-success, browser-open fallback, and timeout. The PR also proactively fixes the 4-second real-sleep problem that would have existed in the happy-path and fallback tests by collapsing `setTimeout` to 0 ms in `beforeEach`.

- **Four test cases** mirror the `connect-github` test structure and exercise all major branches of `connectSlack()`.
- **`setTimeout` mock** in `beforeEach` replaces the 2 000 ms poll delay with 0 ms for all tests, and the timeout test additionally stubs `Date.now` to advance past the 5-minute deadline without waiting.
- **Cleanup is correct**: `afterEach` restores `globalThis.setTimeout`, `Date.now`, `process.exit`, `fetch`, and `GNT_CONFIG_DIR`; `saveApiKey` in `beforeEach` recreates the temp directory after `rmSync` deletes it each cycle.

<h3>Confidence Score: 5/5</h3>

Test-only change with no modifications to production code; safe to merge.

The change is entirely additive test code. All four cases correctly mock and restore globals, the setTimeout-collapse fix eliminates the slow-test concern from the previous review thread, and the Date.now trick in the timeout test is logically sound. No production behaviour is altered.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/test/connect-slack.test.ts | New test file with 4 cases for connectSlack(); includes a correct setTimeout-collapse fix in beforeEach so poll-delay tests don't burn real wall-clock time. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Test (bun:test)
    participant Slack as connectSlack()
    participant Fetch as globalThis.fetch (mock)
    participant Open as open (mock)
    participant Spinner as spinner / stdout

    Test->>Slack: connectSlack()
    Slack->>Fetch: GET /v1/slack/install-url
    alt "status != 200"
        Fetch-->>Slack: 502 error
        Slack->>Test: process.exit(1) throws
    else "status == 200"
        Fetch-->>Slack: "{ url: INSTALL_URL }"
        Slack->>Open: open(INSTALL_URL)
        alt open throws
            Open-->>Slack: Error(no browser)
            Slack->>Spinner: log fallback message
        else open succeeds
            Open-->>Slack: resolved
        end
        loop "while Date.now() < deadline"
            Slack->>Fetch: GET /v1/brain/summary
            alt "slack_connected == true"
                Fetch-->>Slack: "{ slack_connected: true }"
                Slack->>Spinner: stop(Slack connected.)
                Slack-->>Test: return
            else still waiting
                Fetch-->>Slack: "{ slack_connected: false }"
            end
        end
        Slack->>Spinner: stop(Still waiting — run gnt status)
        Slack-->>Test: return
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address review feedback on slack connect..."](https://github.com/gnt-ai/gnt/commit/80e65b23b9cb3c2c0743a624cc1ef35391657244) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50044570)</sub>

<!-- /greptile_comment -->