### PR TITLE
Add Monday.com read-scope documentation to sources.mdx

### DIFF
--- a/apps/docs/pages/docs/sources.mdx
+++ b/apps/docs/pages/docs/sources.mdx
@@ -276,3 +276,30 @@ into candidate rules, which land in your normal review queue exactly like any ot
 ever auto-approved. Disconnecting removes the stored credential immediately.
 
 </details>
+
+<details>
+<summary>**Monday.com**</summary>
+
+`gnt connect monday-mcp` stores a personal access token the same local-only way, and
+`gnt prebrain --monday-mcp --monday-boards <BOARD_ID>` reads straight from monday.com's own
+official MCP server, not through a custom REST client. The adapter deliberately limits itself to
+two read-only tools: `get_board_items_page` for board items and `get_updates` for item updates.
+It never auto-discovers boards; you explicitly list the board IDs you want scanned, and it never
+reads users, workspace settings, or board metadata beyond what those two tools return.
+
+Only an item's own text is ever read: the item's name, its column values joined into prose, and
+the text of updates posted on the item. Assignee names, status labels, dates, and any other
+structured fields are ignored. The adapter runs locally on your device through the same
+CLI-side privacy gate every other prebrain walker uses, and only masked text ever reaches
+extraction.
+
+```bash
+$ gnt connect monday-mcp
+$ gnt prebrain --monday-monday --monday-boards 123456789
+
+Found 18 candidate chunks:
+  Monday.com items: 12 chunks across 3 boards
+  Monday.com updates: 6 chunks across 2 boards
+```
+
+</details>


### PR DESCRIPTION
Fixes #59

Adds a dedicated `<details>` block for Monday.com in `apps/docs/pages/docs/sources.mdx`, matching the format of the existing connector entries.

The adapter reads:
- Board item names and column values (as joined prose)
- Item updates / comments (text only)

It never reads:
- Users, workspace settings, or board metadata
- Assignee names, status labels, dates, or other structured fields
- Any data beyond what `get_board_items_page` and `get_updates` return

Monday.com requires explicit `--monday-boards` IDs; it does not auto-discover boards.

🤖 Generated by New Jerusalem Autobot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup and usage guidance for the Monday.com connector.
  * Documented local token configuration, board-scoped ingestion, supported content, excluded metadata, and privacy handling.
  * Included example commands and expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `<details>` block documenting the Monday.com connector (`gnt connect monday-mcp` / `gnt prebrain`) to `sources.mdx`, following the same structure used by Figma, Datadog, GitLab, and the other existing entries.

- The prose correctly describes the two read-only tools (`get_board_items_page`, `get_updates`) and what data is and is not read.
- The bash code example contains a copy-paste typo (`--monday-monday`) that will produce an error for any user who runs it, and the flag name used in the new section (`--monday-mcp`) contradicts the intro paragraph on the same page, which lists the flag as `--mcp-monday`.

<h3>Confidence Score: 3/5</h3>

Documentation-only change, but the bash example will fail for any user who copies it, and the flag name disagrees with the same page's own intro — both should be resolved before merging.

The new section has two concrete correctness problems: the bash snippet uses `--monday-monday` which is not a real flag, and the section's prose uses `--monday-mcp` while the page's intro paragraph (line 67) spells the same flag `--mcp-monday`. One of these must be wrong, and the broken command in the code block will produce an error for anyone who runs it.

**Files Needing Attention:** apps/docs/pages/docs/sources.mdx — the bash code example and the flag name in the prose both need correction.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/docs/pages/docs/sources.mdx | New Monday.com `<details>` block added in the existing connector format, but contains a broken CLI flag (`--monday-monday`) in the bash example and a flag-name conflict with the page intro (`--monday-mcp` vs `--mcp-monday`). |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as gnt CLI
    participant Token as Local Token Store
    participant MCP as monday.com MCP Server

    User->>CLI: gnt connect monday-mcp
    CLI->>Token: Store personal access token (local only)

    User->>CLI: gnt prebrain --monday-mcp --monday-boards ID
    CLI->>MCP: get_board_items_page(board_id)
    MCP-->>CLI: item names + column values (prose)
    CLI->>MCP: get_updates(board_id)
    MCP-->>CLI: item update text
    CLI->>CLI: Apply privacy gate (mask text)
    CLI-->>User: Candidate chunks ready for review queue
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fdocs%2Fpages%2Fdocs%2Fsources.mdx%3A298%0AThe%20bash%20example%20contains%20a%20typo%3A%20%60--monday-monday%60%20is%20not%20a%20valid%20flag.%20Based%20on%20the%20prose%20directly%20above%2C%20the%20flag%20should%20be%20%60--monday-mcp%60%20%28or%20%60--mcp-monday%60%20as%20listed%20in%20the%20page%20intro%20at%20line%2067%20%E2%80%94%20whichever%20matches%20the%20actual%20CLI%29.%20Any%20user%20who%20copies%20this%20example%20verbatim%20will%20get%20an%20%22unknown%20option%22%20error.%0A%0A%60%60%60suggestion%0A%24%20gnt%20prebrain%20--monday-mcp%20--monday-boards%20123456789%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Aapps%2Fdocs%2Fpages%2Fdocs%2Fsources.mdx%3A283-284%0AThe%20%60gnt%20prebrain%60%20flag%20name%20used%20in%20this%20new%20section%20%28%60--monday-mcp%60%29%20disagrees%20with%20the%20flag%20name%20listed%20in%20the%20page's%20own%20intro%20section%20at%20line%2067%2C%20which%20says%20%60--mcp-monday%60.%20Every%20other%20connector%20on%20that%20line%20follows%20%60--mcp-%3Cname%3E%60%20convention%20%28%60--mcp-notion%60%2C%20%60--mcp-linear%60%2C%20%60--mcp-jira%60%29%2C%20so%20the%20new%20section's%20prose%20and%20code%20example%20likely%20need%20to%20match%20that%20pattern.%20One%20of%20these%20two%20spellings%20is%20incorrect%2C%20and%20the%20mismatch%20will%20confuse%20users%20who%20read%20both%20sections.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=60&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/docs/pages/docs/sources.mdx:298
The bash example contains a typo: `--monday-monday` is not a valid flag. Based on the prose directly above, the flag should be `--monday-mcp` (or `--mcp-monday` as listed in the page intro at line 67 — whichever matches the actual CLI). Any user who copies this example verbatim will get an "unknown option" error.

```suggestion
$ gnt prebrain --monday-mcp --monday-boards 123456789
```

### Issue 2
apps/docs/pages/docs/sources.mdx:283-284
The `gnt prebrain` flag name used in this new section (`--monday-mcp`) disagrees with the flag name listed in the page's own intro section at line 67, which says `--mcp-monday`. Every other connector on that line follows `--mcp-<name>` convention (`--mcp-notion`, `--mcp-linear`, `--mcp-jira`), so the new section's prose and code example likely need to match that pattern. One of these two spellings is incorrect, and the mismatch will confuse users who read both sections.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Monday.com read-scope document..."](https://github.com/gnt-ai/gnt/commit/3c7194121ba4aee95ecb95de2850721bc92b6336) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50118498)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->