### PR TITLE
docs: link connect.mdx to the Hermes Agent page

### DIFF
--- a/apps/docs/pages/docs/connect.mdx
+++ b/apps/docs/pages/docs/connect.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connect
 sidebar_icon: plug
-description: Connect claude.ai, Claude Code, a raw MCP client, an OpenAI agent, or OpenClaw to gnt.
+description: Connect claude.ai, Claude Code, a raw MCP client, an OpenAI agent, OpenClaw, or Hermes to gnt.
 ---
 
 ## claude.ai connectors
@@ -76,3 +76,9 @@ that's what gets OpenClaw to actually call it before acting, not just have it on
   }
 }
 ```
+
+## Hermes Agent
+
+Nous Research's Hermes Agent reads MCP servers straight out of its own config file. Run
+`gnt connect hermes` to wire it up, or see the [Hermes Agent](/docs/hermes-agent) page for the full
+walkthrough, including the skill that gets Hermes to call `check_action` before it acts.


### PR DESCRIPTION
connect.mdx walked through every way to connect gnt to an agent but never mentioned Hermes, even though gnt connect hermes is a real command with its own full docs page.

## What & why



## Test plan



## Before you open this

Reviewers here hold PRs to the same bar the maintainers hold their own changes to. Check these
before requesting review, not after:

- [ ] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [ ] Functionally correct: you ran this, not just read it. If it touches `apps/api` or
      `apps/store`, you ran the relevant test suite locally.
- [ ] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left
      behind.
- [ ] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a
      test. A one-line change doesn't need one; a new code path does.
- [ ] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects
      org/tenant isolation — no query or check that could leak one org's data to another.
- [ ] Matches this repo's existing patterns rather than introducing a new one for the same
      problem — see `CONTRIBUTING.md`'s code conventions.
- [ ] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the
      recall/precision numbers from `bun run eval:extraction -- --mode cloud`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hermes as a supported connection target.
  * Included setup instructions and links to the Hermes walkthrough and `check_action` skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a brief Hermes Agent section to `connect.mdx` so the page is consistent with every other supported connection method. The description front-matter is updated to mention Hermes alongside the other agents.

- Adds a `## Hermes Agent` section with a one-liner on how Hermes reads MCP servers, the `gnt connect hermes` command, and a link to the dedicated `/docs/hermes-agent` page.
- Updates the page `description` field to include \"Hermes\" in the list of supported targets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive documentation change with a valid internal link.

The change adds a short Hermes Agent section to a docs page and updates the description front-matter. The linked page hermes-agent.mdx already exists in the repo, so the link will not 404. No code, config, or behaviour is touched.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/docs/pages/docs/connect.mdx | Documentation-only addition: new Hermes Agent section and updated description front-matter. The linked /docs/hermes-agent page exists in the repo. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[connect.mdx] --> B[claude.ai connectors]
    A --> C[Claude Code]
    A --> D[Raw MCP client Python]
    A --> E[OpenAI-compatible agent]
    A --> F[OpenClaw]
    A --> G[Hermes Agent NEW]
    G -->|gnt connect hermes| H[hermes-agent.mdx]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: link connect.mdx to the Hermes Age..."](https://github.com/gnt-ai/gnt/commit/d462fb33cd19e50848e5b0e87befd8e3f7d4a49b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50120159)</sub>

<!-- /greptile_comment -->