### PR TITLE
docs: add sources.mdx step to the connector checklist

### DIFF
--- a/docs/contributing/adding-a-connector.md
+++ b/docs/contributing/adding-a-connector.md
@@ -249,6 +249,9 @@ automatically the way the CLI's `mcp-framework/registry.ts` works for walkers.
       extraction call.
 - [ ] Platform-admin's `connectors` dict in `routers/platform_admin.py` updated for the new
       connection model.
+- [ ] `apps/docs/pages/docs/sources.mdx` updated with a `<details>` block for the new connector,
+      matching the existing entries' shape: how it connects, what it reads, and what it explicitly
+      never reads — the same privacy boundary the declared `reads` enforce in code.
 - [ ] Tests: a declared-fields test proving undeclared/sensitive fields are unreachable (the
       framework harness for Shape 1, a hand-written test like
       `tests/test_zendesk_client.py` for Shape 2), plus whatever the router/adapter's own logic


### PR DESCRIPTION
Closes #55.

The checklist in `docs/contributing/adding-a-connector.md` walks a contributor through the model, migration, encryption key, RLS decision, registry wiring, the platform-admin `connectors` dict and tests — but never tells them to document the new connector's read scope in `apps/docs/pages/docs/sources.mdx`.

All eight existing MCP-in connectors (Figma, Datadog, GitLab threads, HubSpot, Airtable, Zendesk, Intercom, monday.com) have a `<details>` block there describing exactly what they read and what they never read, so the convention already exists — it is just missing from the checklist. A contributor following the checklist exactly as written today would ship a connector with no entry in that doc.

This adds one checklist item next to the platform-admin dict step, phrased to match the surrounding entries and pointing at the same what-it-reads / what-it-never-reads shape the existing blocks use.

Docs-only change, no code touched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds one missing checklist item to `docs/contributing/adding-a-connector.md`, requiring contributors to update `apps/docs/pages/docs/sources.mdx` with a `<details>` block when shipping a new connector.

- The new item is inserted in a logical position between the platform-admin `connectors` dict step and the tests step, matching the surrounding entries' style and specificity.
- No code is changed; the fix closes a gap where a contributor following the checklist verbatim could ship a connector without any public-facing documentation of its read scope.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single sentence added to a contributor checklist with no code or schema touched.

The change is three lines of markdown that close a documentation gap in the connector checklist. The new item is correctly placed, accurately describes the target file and the format to follow, and ties the documentation requirement back to the privacy boundary that the declared `reads` enforce in code. Nothing executable is modified.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/contributing/adding-a-connector.md | Adds one checklist item pointing contributors to update sources.mdx with a `<details>` block; placement and wording are consistent with the surrounding checklist entries. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Confirm shape with maintainer] --> B[Connection model + migration]
    B --> C[Dedicated encryption key + crypto.py]
    C --> D[RLS eligibility decision]
    D --> E[Validate credential before save]
    E --> F[Never store/log raw token]
    F --> G{Shape?}
    G -->|Shape 1| H[Wire adapter into registry.ts + CLI commands]
    G -->|Shape 2| I[Declared dataclasses, privacy gate, dedup, quota check]
    H --> J[Platform-admin connectors dict]
    I --> J
    J --> K["NEW: Update sources.mdx with details block"]
    K --> L[Tests: declared-fields + router/adapter logic]
    L --> M[PR ready]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add sources.mdx step to the connec..."](https://github.com/gnt-ai/gnt/commit/a8184da747a6092ec1d8c1a1ed40e832f5bca37a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50139842)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the connector contribution checklist to require documentation of connection methods, readable content, and privacy boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->