### PR TITLE
gnt connect datadog tests + apps/api/eval README

### DIFF
--- a/apps/api/eval/README.md
+++ b/apps/api/eval/README.md
@@ -1,0 +1,22 @@
+# Eval suites
+
+This directory holds **quality evals** for retrieval and extraction — measuring
+how well the store finds the right rules against fixture or synthetic corpora.
+These are not the unit/integration tests under `apps/api/tests/`; they answer
+"does hybrid search still retrieve well at this scale?" rather than "does this
+endpoint return 200?"
+
+## Suites
+
+| Suite | CI? | What it measures |
+| --- | --- | --- |
+| [`rule_retrieval/`](rule_retrieval/README.md) | Yes | Hit@k / MRR / recall for `search_rules` on a small, curated corpus (hybrid retrieval + reranker). |
+| [`rule_retrieval_at_scale/`](rule_retrieval_at_scale/README.md) | No (research) | Whether vector-only accuracy degrades vs hybrid as a single-org corpus grows to 1K–1M rules. Runs on free local models only. |
+
+Read each suite's own README for layout, how to run it, and how to interpret results.
+
+## `refund_triage/`
+
+Not present in the tree today. If you see an empty local leftover with that
+name (e.g. from an old WIP), it is unused — safe to ignore or delete locally.
+Do not treat it as a third eval suite.

--- a/apps/cli/test/connect-datadog.test.ts
+++ b/apps/cli/test/connect-datadog.test.ts
@@ -1,0 +1,130 @@
+// Tests the non-TTY parts of `gnt connect datadog` / `gnt disconnect datadog`.
+// The masked/plain keypress readers need a real terminal, so — same as
+// connect-airtable.test.ts — this file covers resolve → validate → save and
+// the disconnect path directly instead of driving keypresses.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { disconnectDatadog } from "../src/commands/connect-datadog.js";
+import { loadMcpToken, saveMcpToken } from "../src/credentials.js";
+import {
+  DATADOG_TOKEN_ID,
+  DEFAULT_DATADOG_SITE,
+  DatadogApiError,
+  resolveDatadogCredentials,
+  serializeDatadogCredentials,
+  validateDatadogCredentials,
+} from "../src/prebrain/datadog-notebooks.js";
+
+let testConfigDir: string;
+let logs: string[];
+let originalLog: typeof console.log;
+let originalApiKeyEnv: string | undefined;
+let originalAppKeyEnv: string | undefined;
+let originalSiteEnv: string | undefined;
+
+beforeEach(() => {
+  testConfigDir = mkdtempSync(join(tmpdir(), "gnt-connect-datadog-test-"));
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  originalApiKeyEnv = process.env.GNT_DATADOG_API_KEY;
+  originalAppKeyEnv = process.env.GNT_DATADOG_APP_KEY;
+  originalSiteEnv = process.env.GNT_DATADOG_SITE;
+  delete process.env.GNT_DATADOG_API_KEY;
+  delete process.env.GNT_DATADOG_APP_KEY;
+  delete process.env.GNT_DATADOG_SITE;
+  logs = [];
+  originalLog = console.log;
+  console.log = mock((...args: unknown[]) => {
+    logs.push(args.join(" "));
+  });
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  rmSync(testConfigDir, { recursive: true, force: true });
+  delete process.env.GNT_CONFIG_DIR;
+  if (originalApiKeyEnv === undefined) delete process.env.GNT_DATADOG_API_KEY;
+  else process.env.GNT_DATADOG_API_KEY = originalApiKeyEnv;
+  if (originalAppKeyEnv === undefined) delete process.env.GNT_DATADOG_APP_KEY;
+  else process.env.GNT_DATADOG_APP_KEY = originalAppKeyEnv;
+  if (originalSiteEnv === undefined) delete process.env.GNT_DATADOG_SITE;
+  else process.env.GNT_DATADOG_SITE = originalSiteEnv;
+});
+
+test("successful save with default site after validate passes", async () => {
+  const fetchImpl = (async () =>
+    new Response(JSON.stringify({ data: [] }), { status: 200 })) as unknown as typeof fetch;
+
+  const creds = resolveDatadogCredentials({
+    apiKey: "dd-api-key",
+    appKey: "dd-app-key",
+  });
+  expect(creds.site).toBe(DEFAULT_DATADOG_SITE);
+
+  await validateDatadogCredentials(creds, fetchImpl);
+  saveMcpToken(DATADOG_TOKEN_ID, serializeDatadogCredentials(creds));
+
+  const stored = loadMcpToken(DATADOG_TOKEN_ID);
+  expect(stored).toBeDefined();
+  expect(JSON.parse(stored!)).toEqual({
+    apiKey: "dd-api-key",
+    appKey: "dd-app-key",
+    site: "datadoghq.com",
+  });
+});
+
+test("successful save with a custom site override", async () => {
+  const fetchImpl = (async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    expect(url).toContain("https://api.datadoghq.eu/");
+    return new Response(JSON.stringify({ data: [] }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const creds = resolveDatadogCredentials({
+    apiKey: "dd-api-key",
+    appKey: "dd-app-key",
+    site: "datadoghq.eu",
+  });
+  expect(creds.site).toBe("datadoghq.eu");
+
+  await validateDatadogCredentials(creds, fetchImpl);
+  saveMcpToken(DATADOG_TOKEN_ID, serializeDatadogCredentials(creds));
+
+  expect(JSON.parse(loadMcpToken(DATADOG_TOKEN_ID)!).site).toBe("datadoghq.eu");
+});
+
+test("validation failure leaves nothing saved", async () => {
+  const fetchImpl = (async () =>
+    new Response(JSON.stringify({ errors: ["Forbidden"] }), { status: 403 })) as unknown as typeof fetch;
+
+  const creds = resolveDatadogCredentials({
+    apiKey: "bad-api-key",
+    appKey: "bad-app-key",
+  });
+
+  await expect(validateDatadogCredentials(creds, fetchImpl)).rejects.toBeInstanceOf(DatadogApiError);
+  expect(loadMcpToken(DATADOG_TOKEN_ID)).toBeUndefined();
+});
+
+test("disconnectDatadog removes a saved connection and reports it removed", async () => {
+  saveMcpToken(
+    DATADOG_TOKEN_ID,
+    serializeDatadogCredentials({
+      apiKey: "dd-api-key",
+      appKey: "dd-app-key",
+      site: "datadoghq.com",
+    }),
+  );
+
+  await disconnectDatadog();
+
+  expect(loadMcpToken(DATADOG_TOKEN_ID)).toBeUndefined();
+  expect(logs.join("\n")).toContain("Disconnected Datadog");
+});
+
+test("disconnectDatadog is a no-op when nothing was connected", async () => {
+  await disconnectDatadog();
+
+  expect(logs.join("\n")).toContain("No stored Datadog connection to remove.");
+});


### PR DESCRIPTION
Closes #41
Closes #51

## Changes
- `apps/cli/test/connect-datadog.test.ts` — covers resolve → validate → save (default + custom site), failed validate (nothing written), and disconnect
- `apps/api/eval/README.md` — quick overview of the two eval suites and a note that `refund_triage/` isn’t a real suite

## How I tested
```bash
cd apps/cli && bun test connect-datadog.test.ts
```
All 5 passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for evaluation suites, including their scope, CI status, and distinction from tests.

- **Tests**
  - Expanded coverage for Datadog connection and disconnection workflows.
  - Added validation for default and custom sites, credential persistence, failed validation handling, and no-op disconnect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds tests for the `gnt connect datadog` / `gnt disconnect datadog` command and a top-level README for the eval directory. Both additions are well-scoped and straightforward.

- **`connect-datadog.test.ts`**: Five tests cover the full non-TTY surface — `resolveDatadogCredentials` with the default site, with a custom site override (including a URL assertion on the fetch call), a 403 rejection that prevents saving, and both states of `disconnectDatadog`. The `beforeEach`/`afterEach` pattern (temp config dir + env-var save/restore) matches the existing `connect-airtable.test.ts`.
- **`apps/api/eval/README.md`**: Documents the two existing suites (`rule_retrieval/` and `rule_retrieval_at_scale/`), their CI status, and explicitly clarifies that `refund_triage/` is not a real suite. Both linked per-suite READMEs are present in the tree.

<h3>Confidence Score: 4/5</h3>

Safe to merge — test-only and documentation additions with no changes to production code paths.

The only thing worth noting is that the URL assertion inside the async fetch mock in the custom-site test will be swallowed by validateDatadogCredentials's catch block if it ever fails, producing a misleading error message instead of a clear expectation failure. This doesn't affect correctness today, but would make a future regression harder to debug.

**Files Needing Attention:** No files require special attention. The test patterns in connect-datadog.test.ts closely mirror connect-airtable.test.ts, and all links in the eval README resolve to files that exist in the repository.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cli/test/connect-datadog.test.ts | New test file covering resolve→validate→save (default + custom site), failed validate, disconnect (connected and empty). Follows the same beforeEach/afterEach pattern as connect-airtable.test.ts. Minor: an expect() assertion inside the fetchImpl mock is swallowed by validateDatadogCredentials's catch, so a URL mismatch reports a confusing DatadogApiError instead of the original assertion failure. |
| apps/api/eval/README.md | New top-level README for the eval directory. Accurately describes both suites (rule_retrieval, rule_retrieval_at_scale), their CI status, and clarifies that refund_triage/ is not a real suite. Links to per-suite READMEs that both exist in the tree. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant resolveDatadogCredentials
    participant validateDatadogCredentials
    participant fetchImpl_mock as fetchImpl (mock)
    participant saveMcpToken
    participant loadMcpToken

    Note over Test: successful save tests
    Test->>resolveDatadogCredentials: "{ apiKey, appKey, site? }"
    resolveDatadogCredentials-->>Test: DatadogCredentials
    Test->>validateDatadogCredentials: (creds, fetchImpl)
    validateDatadogCredentials->>fetchImpl_mock: "GET /api/v1/notebooks?count=1"
    fetchImpl_mock-->>validateDatadogCredentials: "200 { data: [] }"
    validateDatadogCredentials-->>Test: void
    Test->>saveMcpToken: (DATADOG_TOKEN_ID, serialized)
    Test->>loadMcpToken: (DATADOG_TOKEN_ID)
    loadMcpToken-->>Test: stored JSON string

    Note over Test: validation failure test
    Test->>validateDatadogCredentials: (creds, fetchImpl)
    validateDatadogCredentials->>fetchImpl_mock: "GET /api/v1/notebooks?count=1"
    fetchImpl_mock-->>validateDatadogCredentials: "403 { errors: [Forbidden] }"
    validateDatadogCredentials-->>Test: throws DatadogApiError
    Test->>loadMcpToken: (DATADOG_TOKEN_ID)
    loadMcpToken-->>Test: undefined

    Note over Test: disconnectDatadog tests
    Test->>saveMcpToken: pre-seed token
    Test->>disconnectDatadog: ()
    disconnectDatadog->>deleteMcpToken: (DATADOG_TOKEN_ID)
    deleteMcpToken-->>disconnectDatadog: true
    disconnectDatadog-->>Test: logs Disconnected Datadog
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fcli%2Ftest%2Fconnect-datadog.test.ts%3A82-86%0A**URL%20assertion%20swallowed%20inside%20fetchImpl%20mock**%0A%0AThe%20%60expect%28url%29.toContain%28...%29%60%20call%20on%20line%2084%20runs%20inside%20the%20async%20%60fetchImpl%60%20mock%2C%20which%20means%20if%20it%20throws%2C%20%60validateDatadogCredentials%60's%20inner%20%60try%2Fcatch%60%20will%20catch%20it%20and%20re-throw%20it%20as%20%60DatadogApiError%28%22Couldn't%20reach%20Datadog%3A%20...%22%29%60%2C%20masking%20the%20original%20assertion%20failure.%20The%20test%20will%20still%20fail%2C%20but%20Bun%20will%20report%20the%20confusing%20%60DatadogApiError%60%20wrapper%20rather%20than%20the%20expectation%20failure%2C%20making%20the%20root%20cause%20harder%20to%20diagnose.%20Capturing%20the%20URL%20outside%20the%20mock%20and%20asserting%20after%20%60validateDatadogCredentials%60%20resolves%20avoids%20this.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=63&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/cli/test/connect-datadog.test.ts:82-86
**URL assertion swallowed inside fetchImpl mock**

The `expect(url).toContain(...)` call on line 84 runs inside the async `fetchImpl` mock, which means if it throws, `validateDatadogCredentials`'s inner `try/catch` will catch it and re-throw it as `DatadogApiError("Couldn't reach Datadog: ...")`, masking the original assertion failure. The test will still fail, but Bun will report the confusing `DatadogApiError` wrapper rather than the expectation failure, making the root cause harder to diagnose. Capturing the URL outside the mock and asserting after `validateDatadogCredentials` resolves avoids this.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add datadog connect tests and a top-leve..."](https://github.com/gnt-ai/gnt/commit/37079b04a9866763b4eff533617504a3ef1611e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50228153)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->