### PR TITLE
docs/self-hosting/README.md's self-host-vs-hosted note is now stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ gnt org show|rename|invite|remove
 - Self-hosting walkthrough, including the production-hardening path: [`docs/self-hosting/README.md`](docs/self-hosting/README.md)
 - Security policy: [`SECURITY.md`](SECURITY.md)
 
+Self-hosting is a first-class, fully supported path — Apache-2.0 from day one, run it on your own infra with your own keys, or use the hosted version at [gntai.dev](https://gntai.dev). The homepage FAQ and the self-hosting docs both describe this same path; there is no "not today" caveat.
+
 ## License
 
 Copyright © 2026 gnt.ai. Licensed under Apache-2.0 — see [`LICENSE`](LICENSE) for the terms and [`NOTICE`](NOTICE) for the trademark rule on forks.


### PR DESCRIPTION
Fixes #57

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that self-hosting is fully supported under the Apache-2.0 license.
  * Noted that self-hosted deployments use user-managed infrastructure and keys while aligning with the hosted offering and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses issue #57 by adding a clarifying paragraph to the root `README.md` asserting that self-hosting is a first-class, fully supported path and that there is no \"not today\" caveat in the docs or homepage FAQ.

- A single prose paragraph is inserted between the \"Learn more\" bullet list and the `## License` heading, intended to dispel any impression that self-hosting is not fully supported.
- The new paragraph's content substantially overlaps with the pre-existing \"Why is this free?\" subsection directly below the License section, which already explains the same self-hosting vs. hosted distinction in detail.
- The `docs/self-hosting/README.md` file — named in the issue title as having the stale note — is not changed by this PR.

<h3>Confidence Score: 4/5</h3>

Safe to merge — documentation-only change with no code impact.

The added paragraph repeats messaging that already exists in the "Why is this free?" section, leaving two places in the same file saying essentially the same thing. The paragraph also sits structurally between the "Learn more" bullet list and `## License` without fitting neatly into either. Neither issue affects runtime behaviour, but the duplication creates a maintenance burden and could confuse future editors about which section is authoritative. The `docs/self-hosting/README.md` file, named in the issue title as having the stale note, is untouched.

**Files Needing Attention:** README.md — the new paragraph's placement and overlap with "Why is this free?" are worth a second look before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds a prose paragraph between the "Learn more" bullet list and the "## License" heading to clarify that self-hosting is fully supported with no "not today" caveat; the paragraph is structurally orphaned (not a bullet item, not under its own heading) and overlaps significantly with the existing "Why is this free?" subsection directly below. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User reads root README.md] --> B{Deployment choice?}
    B -->|Self-host| C["Clone repo → docker compose up\n(Apache-2.0, free forever)"]
    B -->|Hosted| D["gntai.dev\n(Base / Pro tiers)"]
    C --> E["docs/self-hosting/README.md\n(full walkthrough)"]
    C --> F[Your own Anthropic/Groq/ZeroEntropy keys]
    D --> G[Managed OAuth connectors\nHosted infra & uptime]
    E --> H["Self-host vs. hosted section\n(lines 283–305)"]
    A --> I["'Why is this free?' section\n(line 197 — covers same point\nas newly added paragraph)"]
    A --> J["NEW: Added paragraph\n(line 189 — first-class self-hosting,\nno 'not today' caveat)"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AREADME.md%3A189%0A**Paragraph%20is%20structurally%20orphaned%20and%20duplicates%20existing%20content**%0A%0AThis%20paragraph%20floats%20between%20the%20%22Learn%20more%22%20bullet%20list%20and%20%60%23%23%20License%60%20without%20belonging%20to%20either%20%E2%80%94%20it%20isn't%20a%20list%20item%2C%20a%20sub-heading%2C%20or%20clearly%20part%20of%20the%20section.%20More%20importantly%2C%20the%20%22Why%20is%20this%20free%3F%22%20subsection%20immediately%20below%20the%20License%20section%20%28line%20197%29%20already%20says%20*%22If%20you'd%20rather%20run%20it%20yourself%2C%20that's%20a%20fully%20supported%2C%20fully%20free%20path%2C%20not%20a%20crippled%20trial%20of%20the%20real%20thing%2C%22*%20covering%20the%20same%20point.%20Consider%20either%3A%20%28a%29%20absorbing%20this%20sentence%20into%20%22Why%20is%20this%20free%3F%22%20so%20the%20messaging%20lives%20in%20one%20place%2C%20or%20%28b%29%20converting%20it%20into%20a%20third%20bullet%20under%20%22Learn%20more%22%20so%20it%20fits%20the%20section's%20structure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=64&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:189
**Paragraph is structurally orphaned and duplicates existing content**

This paragraph floats between the "Learn more" bullet list and `## License` without belonging to either — it isn't a list item, a sub-heading, or clearly part of the section. More importantly, the "Why is this free?" subsection immediately below the License section (line 197) already says *"If you'd rather run it yourself, that's a fully supported, fully free path, not a crippled trial of the real thing,"* covering the same point. Consider either: (a) absorbing this sentence into "Why is this free?" so the messaging lives in one place, or (b) converting it into a third bullet under "Learn more" so it fits the section's structure.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: docs/self-hosting/readme.md&#39;s self..."](https://github.com/gnt-ai/gnt/commit/90faac746a15ea559cd4d3909342d1291d00e72a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50288390)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->