### PR TITLE
ci: fix batch-release picking the wrong anchor tag and crashing on version sort

### DIFF
--- a/.github/workflows/batch-release.yml
+++ b/.github/workflows/batch-release.yml
@@ -11,10 +11,15 @@ name: Batch release (public contributions)
 # last release, credit everyone by PR (via --generate-notes) if something
 # did.
 #
-# Diffs from whichever release is most recent chronologically -- a real
-# cli-vX.Y.Z npm release (see publish-cli.yml in the private repo) or a
-# previous batch release, whichever happened last -- so a PR never gets
-# double-credited across both release tracks.
+# Diffs from whichever release tag is closest to main in actual git
+# history -- a real cli-vX.Y.Z npm release (see publish-cli.yml in the
+# private repo) or a previous batch release, whichever a smaller
+# `compare...main` ahead_by picks out -- so a PR never gets double-credited
+# across both release tracks. This has to be ahead_by, not release
+# publishedAt: a release's GitHub "published" timestamp reflects when the
+# release object itself was created, not when its tag lands in history, so
+# two releases can publish out of git order (as cli-v0.6.0 and v1.0.0 did)
+# and sorting by publishedAt alone would pick the wrong anchor.
 #
 # Tagged vX.Y.Z, sequential starting at v1.0.0 -- separate from the
 # cli-vX.Y.Z track, which has to mirror the real published npm version
@@ -45,19 +50,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          last_tag=$(gh release list --repo "${{ github.repository }}" --limit 100 --json tagName,publishedAt --jq 'sort_by(.publishedAt) | last | .tagName // empty')
-          if [ -z "$last_tag" ]; then
+          tags=$(gh release list --repo "${{ github.repository }}" --limit 100 --json tagName --jq '.[].tagName')
+          if [ -z "$tags" ]; then
             echo "No prior release found on this repo -- nothing to diff against, skipping."
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          last_tag=""
+          least_ahead=""
+          while IFS= read -r t; do
+            ahead=$(gh api "repos/${{ github.repository }}/compare/$t...main" --jq '.ahead_by')
+            if [ -z "$least_ahead" ] || [ "$ahead" -lt "$least_ahead" ]; then
+              least_ahead=$ahead
+              last_tag=$t
+            fi
+          done <<< "$tags"
           echo "last_tag=$last_tag" >> "$GITHUB_OUTPUT"
-          ahead=$(gh api "repos/${{ github.repository }}/compare/$last_tag...main" --jq '.ahead_by')
-          if [ "$ahead" -eq 0 ]; then
+          if [ "$least_ahead" -eq 0 ]; then
             echo "Nothing merged since $last_tag -- skipping this week."
             echo "should_release=false" >> "$GITHUB_OUTPUT"
           else
-            echo "$ahead commit(s) since $last_tag -- cutting a batch release."
+            echo "$least_ahead commit(s) since $last_tag -- cutting a batch release."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -67,7 +80,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          last_version=$(gh release list --repo "${{ github.repository }}" --limit 100 --json tagName --jq '[.[].tagName | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(split(".") | map(tonumber)) | last // empty')
+          last_version=$(gh release list --repo "${{ github.repository }}" --limit 100 --json tagName --jq '[.[].tagName | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(ltrimstr("v") | split(".") | map(tonumber)) | last // empty')
           if [ -z "$last_version" ]; then
             tag="v1.0.0"
           else


### PR DESCRIPTION
Ran the batch-release workflow manually to cut this week's release and it crashed. Two real bugs, both invisible until now because this is the first time the increment path (as opposed to the empty-repo default) actually ran:

1. `sort_by(.publishedAt)` picked `cli-v0.6.0` as the diff anchor over `v1.0.0`, because `cli-v0.6.0`'s GitHub release object got published a minute after `v1.0.0`'s even though `v1.0.0` is the newer commit (it's `cli-v0.6.0` + PR #12). Diffing from the wrong anchor would've re-credited every PR already covered by `v1.0.0`'s notes.
2. `split(".") | map(tonumber)` on a raw tag like `v1.0.0` tries to parse `"v1"` as a number and throws, so the release step failed outright.

Fix: pick the anchor tag with the smallest `compare...main` ahead_by (actual git ancestry) instead of publish timestamp, and strip the `v` prefix before the numeric sort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release selection now chooses the closest applicable release tag to the current main branch.
  * Skips creating a release when no releases are available or when the selected release is already current.
  * Improved version detection for standard version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs the weekly batch-release workflow by choosing its notes anchor using Git history rather than release publication time and by stripping the `v` prefix before numerically sorting versions.
- Compares release tags against `main` and selects the smallest `ahead_by`.
- Reuses the selected comparison count when deciding whether a release is needed.
- Makes semantic-version sorting accept tags such as `v1.0.0`.
- Anchor selection should additionally ensure candidates are actually ancestors of `main`.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking hardening opportunity to exclude divergent release tags from anchor selection.

The intended release tracks are handled correctly, while an unrelated release on divergent history could still win the new minimum-ahead comparison and produce notes from the wrong anchor.

**Files Needing Attention:** .github/workflows/batch-release.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/batch-release.yml | Fixes anchor and version selection, but the new anchor algorithm does not verify that the minimum-`ahead_by` tag belongs to `main` ancestry. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Load GitHub release tags] --> B[Compare each tag to main]
    B --> C[Select minimum ahead_by]
    C --> D{Commits ahead?}
    D -->|No| E[Skip release]
    D -->|Yes| F[Sort v-prefixed batch versions]
    F --> G[Increment patch version]
    G --> H[Generate notes from selected anchor]
    H --> I[Create release on main]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fbatch-release.yml%3A62-63%0A**Anchor%20selection%20ignores%20divergence**%0A%0AIf%20a%20GitHub%20release%20tag%20points%20to%20divergent%20history%20with%20a%20recent%20merge%20base%2C%20minimizing%20only%20%60ahead_by%60%20can%20select%20it%20even%20though%20it%20is%20not%20an%20ancestor%20of%20%60main%60%2C%20causing%20generated%20release%20notes%20to%20use%20the%20wrong%20commit%20range%20and%20omit%20or%20re-credit%20contributions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/batch-release.yml:62-63
**Anchor selection ignores divergence**

If a GitHub release tag points to divergent history with a recent merge base, minimizing only `ahead_by` can select it even though it is not an ancestor of `main`, causing generated release notes to use the wrong commit range and omit or re-credit contributions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: fix batch-release picking the wrong ..."](https://github.com/gnt-ai/gnt/commit/3b772f95bc04b8b66329095982f3a8938f91e86c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50796444)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->