### PR TITLE
ci: bump batch-release cadence from weekly to every 3 days

### DIFF
--- a/.github/workflows/batch-release.yml
+++ b/.github/workflows/batch-release.yml
@@ -1,13 +1,13 @@
 name: Batch release (public contributions)
 
-# Weekly digest of whatever merged into main since the last release --
-# not every PR deserves its own release (noisy: a repo where every doc
-# typo fix gets its own release entry trains people to ignore the
-# Releases tab), but waiting for an unrelated future npm version bump to
-# sweep up an external contribution isn't good either -- that's exactly
-# what almost happened to gnt-ai/gnt#12, the project's first outside PR,
-# before it got a manual one-off release instead. This is the automated
-# middle ground: check weekly, skip silently if nothing merged since the
+# Digest of whatever merged into main since the last release -- not every
+# PR deserves its own release (noisy: a repo where every doc typo fix
+# gets its own release entry trains people to ignore the Releases tab),
+# but waiting for an unrelated future npm version bump to sweep up an
+# external contribution isn't good either -- that's exactly what almost
+# happened to gnt-ai/gnt#12, the project's first outside PR, before it
+# got a manual one-off release instead. This is the automated middle
+# ground: check every 3 days, skip silently if nothing merged since the
 # last release, credit everyone by PR (via --generate-notes) if something
 # did.
 #
@@ -33,7 +33,7 @@ name: Batch release (public contributions)
 
 on:
   schedule:
-    - cron: "0 9 * * 1" # every Monday, 09:00 UTC
+    - cron: "0 9 */3 * *" # every 3 days, 09:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Weekly was leaving external contributions sitting unreleased for up to 6 days. Switches the cron to every 3 days; it already no-ops when nothing's merged since the last release, so this just tightens the check interval.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR increases the batch-release workflow frequency by replacing its weekly schedule with a day-of-month cron step and updates the surrounding documentation.
- Changes the scheduled release check from Monday mornings to `0 9 */3 * *`.
- Updates comments to describe an intended three-day cadence.

<h3>Confidence Score: 4/5</h3>

The cron expression should be corrected before merging because it does not implement the stated every-three-days cadence.

A stepped day-of-month field resets each month, producing irregular intervals and occasionally consecutive daily runs instead of a continuous three-day schedule.

**Files Needing Attention:** .github/workflows/batch-release.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/batch-release.yml | The documentation and cron were updated together, but the cron expression does not maintain a three-day interval across month boundaries. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fbatch-release.yml%3A36%0A**Cron%20interval%20resets%20monthly**%0A%0AWhen%20the%20calendar%20month%20changes%2C%20the%20%60*%2F3%60%20day-of-month%20step%20resets%20instead%20of%20maintaining%20a%20continuous%20three-day%20interval%2C%20causing%20release%20checks%20to%20cluster%20or%20drift%20at%20month%20boundaries%E2%80%94for%20example%2C%20January%2031%20and%20February%201%20run%20only%20one%20day%20apart.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=68&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/batch-release.yml:36
**Cron interval resets monthly**

When the calendar month changes, the `*/3` day-of-month step resets instead of maintaining a continuous three-day interval, causing release checks to cluster or drift at month boundaries—for example, January 31 and February 1 run only one day apart.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: bump batch-release cadence from week..."](https://github.com/gnt-ai/gnt/commit/3735f463246ffc0fdc4256e427d311d601122527) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50798292)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->