### PR TITLE
test(store): cover github-clone pullRepo and auth-failure paths

### DIFF
--- a/apps/store/test/github-clone.test.ts
+++ b/apps/store/test/github-clone.test.ts
@@ -6,19 +6,38 @@
  * HTTP boundary. This file covers the two gaps that suite still leaves:
  *   1. cloneOrPull on an already-cloned dest takes pullRepo and picks up
  *      new commits from the source.
- *   2. An auth failure against a real HTTPS remote returns GithubCloneError
- *      whose message never echoes the PAT (or the Authorization header argv).
+ *   2. An auth failure against an HTTPS remote returns GithubCloneError
+ *      whose message never echoes the PAT (plaintext or Base64-encoded).
  *
  * Local-path clones don't exercise auth (http.extraHeader is
- * transport-specific), so (2) needs a live network call to GitHub. It
- * skips cleanly when offline.
+ * transport-specific), so (2) uses a local HTTP server that always
+ * returns 401 — deterministic and fully offline.
  */
 import { execFileSync } from "node:child_process";
+import { createServer } from "node:http";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AddressInfo } from "node:net";
 import { describe, expect, test } from "bun:test";
 import { GithubCloneError, cloneOrPull, cloneRepo } from "../src/core/github-clone.ts";
+
+function startUnauthorizedGitServer(): Promise<{ repoUrl: string; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((_req, res) => {
+      res.writeHead(401, { "WWW-Authenticate": 'Basic realm="git"' });
+      res.end("Unauthorized");
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({
+        repoUrl: `http://127.0.0.1:${addr.port}/fake.git`,
+        close: () => server.close(),
+      });
+    });
+  });
+}
 
 function initSourceRepo(files: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), "gnt-clone-src-"));
@@ -93,36 +112,29 @@ describe("cloneOrPull", () => {
 
 describe("cloneOrPull auth failure", () => {
   test("a rejected PAT fails cleanly without leaking the token", async () => {
-    // GitHub rejects invalid Authorization even on public repos — that's
-    // enough to exercise runGit's stderr-only error path without needing
-    // a private fixture. Skip when the network is unreachable so offline
-    // `bun test` runs stay green.
-    const probe = await fetch("https://github.com/", { method: "HEAD", signal: AbortSignal.timeout(5_000) }).catch(
-      () => null,
-    );
-    if (!probe) {
-      console.warn("skipping auth-failure test: github.com unreachable");
-      return;
-    }
-
     const badPat = "ghp_thisIsDefinitelyNotARealToken_xxxxxxxxxxxxxxxxxxxx";
+    const encodedPat = Buffer.from(`x-access-token:${badPat}`).toString("base64");
     const dest = join(mkdtempSync(join(tmpdir(), "gnt-clone-auth-")), "repo");
+    const server = await startUnauthorizedGitServer();
 
     let err: unknown;
     try {
-      await cloneOrPull("https://github.com/gnt-ai/gnt.git", badPat, dest);
+      await cloneOrPull(server.repoUrl, badPat, dest);
     } catch (e) {
       err = e;
+    } finally {
+      server.close();
     }
 
     expect(err).toBeInstanceOf(GithubCloneError);
     const message = String((err as Error).message);
     expect(message.length).toBeGreaterThan(0);
     expect(message).not.toContain(badPat);
+    expect(message).not.toContain(encodedPat);
     expect(message).not.toContain("Authorization");
     expect(message).not.toContain("extraHeader");
     expect(message).not.toContain("x-access-token");
     // Failed clone must clean up the partial dest dir.
     expect(existsSync(dest)).toBe(false);
-  }, 90_000);
+  });
 });

--- a/apps/store/test/github-clone.test.ts
+++ b/apps/store/test/github-clone.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Direct coverage for apps/store/src/core/github-clone.ts — the plumbing
+ * behind every /sync that needs a fresh or updated local checkout.
+ *
+ * http-server.test.ts already covers the bad-local-path → 502 path at the
+ * HTTP boundary. This file covers the two gaps that suite still leaves:
+ *   1. cloneOrPull on an already-cloned dest takes pullRepo and picks up
+ *      new commits from the source.
+ *   2. An auth failure against a real HTTPS remote returns GithubCloneError
+ *      whose message never echoes the PAT (or the Authorization header argv).
+ *
+ * Local-path clones don't exercise auth (http.extraHeader is
+ * transport-specific), so (2) needs a live network call to GitHub. It
+ * skips cleanly when offline.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { GithubCloneError, cloneOrPull, cloneRepo } from "../src/core/github-clone.ts";
+
+function initSourceRepo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "gnt-clone-src-"));
+  execFileSync("git", ["init", "-q", "-b", "main", dir]);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(dir, relativePath);
+    mkdirSync(fullPath.slice(0, fullPath.lastIndexOf("/")), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  execFileSync("git", ["-C", dir, "add", "-A"]);
+  execFileSync("git", [
+    "-C",
+    dir,
+    "-c",
+    "user.email=test@test.com",
+    "-c",
+    "user.name=test",
+    "commit",
+    "-q",
+    "-m",
+    "seed",
+  ]);
+  return dir;
+}
+
+function commitNewFile(dir: string, relativePath: string, content: string, message: string): void {
+  const fullPath = join(dir, relativePath);
+  mkdirSync(fullPath.slice(0, fullPath.lastIndexOf("/")), { recursive: true });
+  writeFileSync(fullPath, content);
+  execFileSync("git", ["-C", dir, "add", "-A"]);
+  execFileSync("git", [
+    "-C",
+    dir,
+    "-c",
+    "user.email=test@test.com",
+    "-c",
+    "user.name=test",
+    "commit",
+    "-q",
+    "-m",
+    message,
+  ]);
+}
+
+describe("cloneOrPull", () => {
+  test("second call on an existing clone takes pullRepo and picks up new commits", async () => {
+    const source = initSourceRepo({ "rules/seed.md": "v1\n" });
+    const dest = join(mkdtempSync(join(tmpdir(), "gnt-clone-dst-")), "repo");
+
+    await cloneOrPull(source, "unused-for-a-local-repo", dest);
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+    expect(readFileSync(join(dest, "rules/seed.md"), "utf8")).toBe("v1\n");
+
+    commitNewFile(source, "rules/after-pull.md", "picked up by pull\n", "add after clone");
+
+    // dest/.git already exists — cloneOrPull must pull, not re-clone
+    // (re-clone would throw "already exists — use pullRepo instead").
+    await cloneOrPull(source, "unused-for-a-local-repo", dest);
+    expect(readFileSync(join(dest, "rules/after-pull.md"), "utf8")).toBe("picked up by pull\n");
+    expect(readFileSync(join(dest, "rules/seed.md"), "utf8")).toBe("v1\n");
+  });
+
+  test("cloneRepo refuses a dest that already exists", async () => {
+    const source = initSourceRepo({ "rules/seed.md": "v1\n" });
+    const dest = join(mkdtempSync(join(tmpdir(), "gnt-clone-exists-")), "repo");
+    await cloneRepo(source, "unused", dest);
+
+    await expect(cloneRepo(source, "unused", dest)).rejects.toBeInstanceOf(GithubCloneError);
+    await expect(cloneRepo(source, "unused", dest)).rejects.toThrow(/already exists/);
+  });
+});
+
+describe("cloneOrPull auth failure", () => {
+  test("a rejected PAT fails cleanly without leaking the token", async () => {
+    // GitHub rejects invalid Authorization even on public repos — that's
+    // enough to exercise runGit's stderr-only error path without needing
+    // a private fixture. Skip when the network is unreachable so offline
+    // `bun test` runs stay green.
+    const probe = await fetch("https://github.com/", { method: "HEAD", signal: AbortSignal.timeout(5_000) }).catch(
+      () => null,
+    );
+    if (!probe) {
+      console.warn("skipping auth-failure test: github.com unreachable");
+      return;
+    }
+
+    const badPat = "ghp_thisIsDefinitelyNotARealToken_xxxxxxxxxxxxxxxxxxxx";
+    const dest = join(mkdtempSync(join(tmpdir(), "gnt-clone-auth-")), "repo");
+
+    let err: unknown;
+    try {
+      await cloneOrPull("https://github.com/gnt-ai/gnt.git", badPat, dest);
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(GithubCloneError);
+    const message = String((err as Error).message);
+    expect(message.length).toBeGreaterThan(0);
+    expect(message).not.toContain(badPat);
+    expect(message).not.toContain("Authorization");
+    expect(message).not.toContain("extraHeader");
+    expect(message).not.toContain("x-access-token");
+    // Failed clone must clean up the partial dest dir.
+    expect(existsSync(dest)).toBe(false);
+  }, 90_000);
+});


### PR DESCRIPTION
## What & why

Closes #47.

`cloneOrPull`'s re-sync branch (`pullRepo` when `dest/.git` already exists) and auth-failure error sanitization were untested. Adds `apps/store/test/github-clone.test.ts` covering:

- Second `cloneOrPull` on an existing local clone takes the pull path and picks up new commits from the source
- A rejected PAT against a real GitHub HTTPS remote raises `GithubCloneError` without leaking the token / Authorization argv, and cleans up the partial dest

## Test plan

- [x] `cd apps/store && bun test test/github-clone.test.ts` — 3 pass
- [ ] CI store + security jobs green on this PR

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or
      `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left
      behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a
      test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects
      org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same
      problem — see `CONTRIBUTING.md`'s code conventions.
- [ ] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the
      recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for repository cloning and updating existing local copies.
  - Added validation for clear handling when a destination already exists.
  - Verified authentication failures are reported safely without exposing credentials or authorization details.
  - Confirmed incomplete clone attempts clean up temporary files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic, offline coverage for cloning, pulling updates into an existing checkout, authentication-failure sanitization, and partial-destination cleanup.
- Uses a loopback HTTP server returning 401 instead of relying on live GitHub behavior.
- Checks both plaintext and production-equivalent Base64 credential representations.
- Verifies existing destinations and failed clone cleanup behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the prior nondeterministic live-network dependency and encoded-credential assertion gap are both addressed by the current test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/store/test/github-clone.test.ts | Adds local Git fixtures and an offline unauthorized HTTP endpoint that address both previously reported test-coverage defects. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(store): make github-clone auth fail..."](https://github.com/gnt-ai/gnt/commit/7054ac101b743c0f03a61c106805366af12ce618) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50843608)</sub>

<!-- /greptile_comment -->