### PR TITLE
ci: add automated DCO Signed-off-by check

### DIFF
--- a/.github/scripts/check_dco.py
+++ b/.github/scripts/check_dco.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""DCO (Developer Certificate of Origin) check for commit ranges.
+
+CONTRIBUTING.md requires every commit to carry a `Signed-off-by` trailer
+matching the commit author (`git commit -s`). This script enforces that in
+CI the same way check_workflow_security.py enforces fork-PR safety: a small
+stdlib Python check, no third-party Action, no GitHub App install.
+
+Why a workflow script instead of the dcoapp GitHub App: this repo's CI
+policy checks already live as scripts under .github/scripts/ and run on
+ubuntu-latest for fork PRs. A script fits that pattern, needs no org-level
+App install, and stays fork-safe by construction (hosted runner only).
+
+Usage:
+  BASE_SHA=<merge-base> HEAD_SHA=<tip> python3 .github/scripts/check_dco.py
+
+CI sets BASE_SHA/HEAD_SHA from the pull_request or push event. Locally,
+point them at any range you want to verify.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def run_git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).rstrip("\n")
+
+
+def commit_range(base: str, head: str) -> list[str]:
+    # Exclusive of base, inclusive of head — the commits a PR actually adds.
+    out = run_git("rev-list", "--no-merges", f"{base}..{head}")
+    return [line for line in out.splitlines() if line]
+
+
+def author_identity(sha: str) -> str:
+    return run_git("show", "--no-patch", "--format=%an <%ae>", sha)
+
+
+def trailers(sha: str) -> str:
+    # interpret-trailers --parse is the same parser `git commit -s` writes
+    # for; grepping %B directly would false-positive on body text that
+    # happens to mention "Signed-off-by".
+    body = run_git("show", "--no-patch", "--format=%B", sha)
+    return subprocess.check_output(
+        ["git", "interpret-trailers", "--parse"],
+        input=body,
+        text=True,
+    )
+
+
+def check_commit(sha: str) -> str | None:
+    expected = f"Signed-off-by: {author_identity(sha)}"
+    parsed = trailers(sha)
+    if any(line == expected for line in parsed.splitlines()):
+        return None
+    short = run_git("rev-parse", "--short", sha)
+    subject = run_git("show", "--no-patch", "--format=%s", sha)
+    if "Signed-off-by:" in parsed:
+        return (
+            f"{short} ({subject}): Signed-off-by present but does not match "
+            f"author — expected exactly `{expected}`"
+        )
+    return f"{short} ({subject}): missing `{expected}`"
+
+
+def main() -> int:
+    base = os.environ.get("BASE_SHA", "").strip()
+    head = os.environ.get("HEAD_SHA", "").strip()
+    if not base or not head:
+        print(
+            "BASE_SHA and HEAD_SHA must both be set (CI sets them from the "
+            "pull_request/push event)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        commits = commit_range(base, head)
+    except subprocess.CalledProcessError as e:
+        print(f"failed to list commits in {base}..{head}: {e}", file=sys.stderr)
+        return 2
+
+    if not commits:
+        print(f"DCO check: OK (no non-merge commits in {base[:7]}..{head[:7]})")
+        return 0
+
+    errors = [err for sha in commits if (err := check_commit(sha)) is not None]
+    if errors:
+        for err in errors:
+            print(f"::error::{err}")
+        print(
+            f"\n{len(errors)} commit(s) failed the DCO check. "
+            "Re-sign with `git commit --amend -s` (tip) or "
+            "`git rebase --signoff <base>` (older commits). "
+            "See CONTRIBUTING.md's DCO section.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"DCO check: OK ({len(commits)} commit(s) signed off)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -199,4 +199,16 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
-        run: python3 .github/scripts/check_dco.py
+        run: |
+          # Run the checker from the trusted base revision, not the PR head.
+          # A PR must not be able to weaken enforcement by editing check_dco.py.
+          TRUSTED_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ "$TRUSTED_SHA" = "0000000000000000000000000000000000000000" ] || \
+             ! git cat-file -e "${TRUSTED_SHA}:.github/scripts/check_dco.py" 2>/dev/null; then
+            # First introduction on the base branch — reviewers validate the
+            # script in the PR itself; after merge, future PRs use main's copy.
+            cp .github/scripts/check_dco.py /tmp/check_dco.py
+          else
+            git show "${TRUSTED_SHA}:.github/scripts/check_dco.py" > /tmp/check_dco.py
+          fi
+          python3 /tmp/check_dco.py

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -173,3 +173,30 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - run: python3 .github/scripts/check_workflow_security.py
+
+  # Workflow/script-based (not the dcoapp GitHub App): matches this repo's
+  # existing policy-check pattern (check_workflow_security.py above), needs
+  # no org-level App install, and stays fork-safe by running on ubuntu-latest
+  # only — same hosted-runner discipline CONTRIBUTING.md / issue #58 call out.
+  dco:
+    name: dco (Signed-off-by)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # push with before=000… is a new-branch / first-push edge where there's
+    # no meaningful parent range; workflow_dispatch has no commit range at
+    # all. PRs and ordinary pushes to main are what we care about.
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # Full history so BASE_SHA..HEAD_SHA is resolvable even when the
+          # PR is many commits deep — a shallow clone would make rev-list
+          # miss (or fail to find) the base.
+          fetch-depth: 0
+      - name: Verify DCO sign-offs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
+        run: python3 .github/scripts/check_dco.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,10 @@ certifying you wrote the change (or otherwise have the right to submit it) under
 Linux kernel and a lot of other open-source projects use instead of a CLA. It's a statement,
 not paperwork: no separate form, no signing tool, just the flag on `git commit`.
 
-There's no automated DCO check wired into CI yet. That's a real gap, tracked as follow-up, not
-something this PR (or any PR) should assume is enforced. Sign off anyway; it'll get checked by
-a maintainer by hand until the bot exists.
+CI enforces this on every PR (and on pushes to `main`): the `dco` job in
+`.github/workflows/security.yml` runs `.github/scripts/check_dco.py`, which fails the check if
+any non-merge commit in the range is missing an author-matching `Signed-off-by` trailer. Fix a
+tip commit with `git commit --amend -s`, or older commits with `git rebase --signoff <base>`.
 
 ## Opening a PR
 


### PR DESCRIPTION
## What & why

Closes #58.

**Choice: workflow/script, not the dcoapp GitHub App.** Reason: matches this repo's existing policy-check pattern (`.github/scripts/check_workflow_security.py`), needs no org-level App install, and stays fork-safe by running on `ubuntu-latest` only.

Adds:

- `.github/scripts/check_dco.py` — verifies every non-merge commit in `BASE_SHA..HEAD_SHA` has an author-matching `Signed-off-by` trailer (`git interpret-trailers --parse`)
- `dco` job in `.github/workflows/security.yml`
- `CONTRIBUTING.md` update now that CI enforces the trailer

## Test plan

Local fixtures against a temp repo:

- [x] Signed commit → exit 0
- [x] Missing `Signed-off-by` → exit 1
- [x] Present but wrong author → exit 1
- [x] Fixed with `git commit --amend -s` → exit 0
- [x] `python3 .github/scripts/check_workflow_security.py` still OK with the new job
- [x] This PR's own commit range passes the DCO script
- [ ] CI `dco` job green on this PR (and would fail a deliberately unsigned commit)

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or
      `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left
      behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a
      test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects
      org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same
      problem — see `CONTRIBUTING.md`'s code conventions.
- [ ] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the
      recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify that commits include matching `Signed-off-by` signatures.
  * Checks run for pull requests and updates to the main branch, with clear validation results.

* **Documentation**
  * Updated contribution guidance to explain automated DCO enforcement and how to correct unsigned commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automated DCO validation and contributor guidance, but the bootstrap path does not fully establish the intended trust boundary.
- Adds a Python checker for author-matching `Signed-off-by` trailers.
- Adds a DCO workflow job intended to execute a checker from the trusted base revision.
- Documents CI-enforced DCO requirements and remediation commands.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the initial trusted-checker bootstrap still permits pull-request-controlled DCO validation.

When the base lacks the newly introduced checker, the workflow copies that checker from the pull-request checkout and executes it, so unsigned commits can obtain a passing DCO result by replacing the validator.

**Files Needing Attention:** .github/workflows/security.yml

<details open><summary><h3>Security Review</h3></summary>

The bootstrap fallback remains PR-controlled when the base revision lacks the checker, so an initial or pre-DCO-base pull request can replace the validator and bypass sign-off enforcement.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/security.yml | Adds the DCO job and trusted-base extraction, but its bootstrap fallback still executes the PR-controlled checker. |
| .github/scripts/check_dco.py | Implements commit-range and author-matching trailer validation; its effectiveness depends on executing a trusted revision. |
| CONTRIBUTING.md | Updates DCO documentation to describe CI enforcement and commands for repairing unsigned commits. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve trusted base SHA] --> B{Base contains check_dco.py?}
  B -- Yes --> C[Extract checker from base]
  B -- No --> D[Copy checker from PR checkout]
  C --> E[Validate commit range]
  D --> E
  D --> F[PR can control validation result]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fsecurity.yml%3A208-210%0A**Bootstrap%20checker%20remains%20PR-controlled**%0A%0AWhen%20the%20base%20revision%20does%20not%20contain%20%60.github%2Fscripts%2Fcheck_dco.py%60%2C%20this%20fallback%20copies%20and%20executes%20the%20checker%20from%20the%20pull-request%20checkout%2C%20allowing%20an%20always-successful%20replacement%20to%20give%20unsigned%20commits%20a%20passing%20DCO%20status.%20**How%20this%20was%20verified%3A**%20The%20checker%20is%20newly%20added%20relative%20to%20the%20PR%20base%2C%20and%20the%20fallback%20explicitly%20copies%20it%20from%20the%20checked-out%20PR%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=gnt-ai%2Fgnt&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/security.yml:208-210
**Bootstrap checker remains PR-controlled**

When the base revision does not contain `.github/scripts/check_dco.py`, this fallback copies and executes the checker from the pull-request checkout, allowing an always-successful replacement to give unsigned commits a passing DCO status. **How this was verified:** The checker is newly added relative to the PR base, and the fallback explicitly copies it from the checked-out PR content.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: run DCO checker from trusted base re..."](https://github.com/gnt-ai/gnt/commit/09a39c1013935a815eefd4108e9ef879765461e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50843643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->