### PR TITLE
test(store): cover POST /ingest success and schema-invalid paths

### DIFF
--- a/apps/store/test/http-server.test.ts
+++ b/apps/store/test/http-server.test.ts
@@ -488,6 +488,33 @@ describe.skipIf(!reachable)("internal HTTP API", () => {
     expect(rule.tags.sort()).toEqual(["billing", "refunds"]);
   });
 
+  test("POST /ingest with a valid batch returns an IngestReceipt", async () => {
+    const org = `org-http-ingest-${RUN_ID}`;
+    const res = await authed("/ingest", {
+      method: "POST",
+      body: JSON.stringify({
+        org,
+        sourceKind: "capture",
+        text: "Customer asked about the 30-day refund window.",
+        ref: "evt-http-ingest-1",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const receipt = (await res.json()) as { org: string; draftSlugs: string[] };
+    expect(receipt.org).toBe(org);
+    expect(Array.isArray(receipt.draftSlugs)).toBe(true);
+  });
+
+  test("POST /ingest with a schema-invalid body gets 400, not a raw 500", async () => {
+    // Missing required fields (sourceKind/text/ref) — same 400 shape as the
+    // malformed /rules and /sources cases already in this file.
+    const res = await authed("/ingest", {
+      method: "POST",
+      body: JSON.stringify({ org: `org-http-ingest-bad-${RUN_ID}` }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   // Org offboarding's store-side delete.
   test("POST /sources/delete removes an org's rules mirror — the deleted rule is gone afterward", async () => {
     const rule = makeRule({ slug: "rules/http-delete-me", org: "org-http-delete" });


### PR DESCRIPTION
## What & why

Closes #43.

`/ingest` was only covered by the bearer-token auth check. Adds:

- Valid authenticated batch → 200 with an `IngestReceipt` (`org` + `draftSlugs`)
- Schema-invalid body → 400 (same shape as other malformed-body cases in this file)

## Test plan

- [x] `cd apps/store && bun test test/http-server.test.ts` — 32 pass (incl. the two new cases)
- [ ] CI store job green on this PR

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: you ran this, not just read it. If it touches `apps/api` or
      `apps/store`, you ran the relevant test suite locally.
- [x] No dead code — no unused imports/variables, no commented-out blocks, no debug logging left
      behind.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a
      test. A one-line change doesn't need one; a new code path does.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects
      org/tenant isolation — no query or check that could leak one org's data to another.
- [x] Matches this repo's existing patterns rather than introducing a new one for the same
      problem — see `CONTRIBUTING.md`'s code conventions.
- [ ] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the
      recall/precision numbers from `bun run eval:extraction -- --mode cloud`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added HTTP integration coverage for successful batch ingestion.
  * Added validation coverage confirming malformed ingestion requests are rejected with a 400 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds HTTP integration coverage for authenticated `/ingest` requests.
- Verifies that a valid ingest batch returns a successful receipt containing the requested organization and a draft-slug array.
- Verifies that a schema-invalid ingest body returns HTTP 400 rather than an internal-server error.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only adds focused coverage for existing `/ingest` behavior and introduces no application behavior changes.

The valid request matches the ingest schema and current receipt contract, while the invalid request correctly exercises the shared schema-validation path and expects HTTP 400.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/store/test/http-server.test.ts | Adds focused success and schema-validation tests for POST `/ingest`; no actionable defects were identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(store): cover POST /ingest success ..."](https://github.com/gnt-ai/gnt/commit/4692d421c4ec2c7b3216ffe4dfdf18f74dbad7d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50853261)</sub>

<!-- /greptile_comment -->