### PR TITLE
ci: ignore GHSA-5p4m-2wfm-xmqj, unfixed js-yaml ReDoS via zudoku

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,18 @@ auditConfig:
     # no real attack surface here either: apps/docs ships as a static
     # Vite build with no server runtime for a CSRF bypass to act on.
     - GHSA-qwww-vcr4-c8h2
+    # js-yaml, high severity: pinned inside apps/docs' own zudoku
+    # dependency tree (zudoku > gray-matter > js-yaml, and separately
+    # zudoku > @apidevtools/json-schema-ref-parser > js-yaml), not
+    # something any app code here pulls in directly. The advisory's own
+    # title says the fix wasn't backported to either the 3.x or 4.x line
+    # js-yaml resolves to here, so there's no version to bump to. The
+    # vulnerability itself (quadratic CPU consumption resolving a crafted
+    # `!!omap` YAML tag) needs an attacker-controlled YAML document fed to
+    # js-yaml's parser at runtime -- apps/docs ships as a static Vite
+    # build with no server runtime parsing untrusted YAML, so there's no
+    # real attack surface here either.
+    - GHSA-5p4m-2wfm-xmqj
 minimumReleaseAgeExclude:
   - lodash@4.17.23 || 4.17.24
   - drizzle-orm@0.45.2


### PR DESCRIPTION
pnpm audit started failing on every open PR today (not just ones touching apps/docs -- js-audit scans the whole workspace lockfile regardless of what changed). Same shape as the existing `GHSA-qwww-vcr4-c8h2` entry: js-yaml is pinned inside zudoku's own dependency tree (`gray-matter` and `@apidevtools/json-schema-ref-parser` both pull it in), the advisory's own title says the fix wasn't backported to either resolved major version, and the vulnerability needs an attacker-controlled YAML document fed to the parser at runtime -- apps/docs is a static Vite build with no server parsing untrusted YAML, so there's no real attack surface here.

## Test plan

`pnpm install --frozen-lockfile && pnpm audit` locally: before this change, 3 high severity findings (1 already ignored, 2 new). After: `3 vulnerabilities found / Severity: 3 high (3 ignored)`, exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documented an exception for a transitive dependency vulnerability that does not affect the static documentation build’s runtime attack surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows workspace audits to pass by ignoring GHSA-5p4m-2wfm-xmqj for unfixed transitive js-yaml versions used by the static documentation toolchain.
- Documents the affected zudoku dependency paths and vulnerable parser behavior.
- Explains why repository-controlled build inputs do not provide the attacker-controlled YAML required to exploit the advisory.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the ignored advisory has no attacker-controlled input path in the affected documentation dependencies.

The affected js-yaml versions are used at build time for committed MDX frontmatter, the committed OpenAPI specification, and development configuration; the generated documentation has no server-side YAML parsing path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Adds a justified audit exception for an unfixed transitive js-yaml advisory whose vulnerable parsing paths process only repository-controlled build inputs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: ignore GHSA-5p4m-2wfm-xmqj, unfixed ..."](https://github.com/gnt-ai/gnt/commit/5694e85da4ab245f7614bdc21639b3a37c59e653) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51010993)</sub>

<!-- /greptile_comment -->