### PR TITLE
drop the per-PR changelog-edit requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,11 @@ even if they touch the same file. A PR that fixes a bug and also refactors the f
 it is two PRs. This isn't bureaucracy: a scoped PR is fast to review and safe to revert on its
 own; a bundled one makes both changes hostage to whichever part is slower to land.
 
-**User-facing changes get a changelog entry.** If your PR changes something a customer or
-contributor would notice (CLI behavior, API responses, docs that ship with a release), add a
-short bullet under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) in the same PR. Don't
-invent detail for pre-changelog versions — just keep the Unreleased section current going
-forward.
+**Don't hand-edit `CHANGELOG.md`.** It used to ask for a bullet under `## [Unreleased]` in every
+PR, which meant any two PRs touching it at the same time conflicted with each other — pure
+overhead, since `batch-release.yml`'s releases are generated from merged PR titles
+(`--generate-notes`), not from this file. Write a clear PR title instead; that's what shows up
+in the release notes. `CHANGELOG.md` gets rolled up separately, outside your PR.
 
 **Show it actually works, not just that it compiles.** State how a reviewer can confirm your
 change does what you say, in the PR description:


### PR DESCRIPTION
CONTRIBUTING.md asked every PR to hand-edit CHANGELOG.md's Unreleased list. That's the exact conflict I resolved by hand across 4 PRs today -- any two PRs touching it at once collide. It also wasn't buying anything: batch-release.yml generates release notes from merged PR titles (--generate-notes), it never reads CHANGELOG.md.

Also flipped two repo settings as part of the same cleanup: allow_auto_merge and allow_update_branch, both were off, which is why every stale PR today needed a maintainer to manually pull+resolve+push instead of a contributor self-serving the "update branch" button GitHub already provides.