### PR TITLE
docs(goose): add gnt integration guide

### DIFF
--- a/integrations/goose/CONNECT.md
+++ b/integrations/goose/CONNECT.md
@@ -1,0 +1,78 @@
+# Connecting Goose to gnt-brain
+
+gnt-brain is gnt's rules-governance MCP server. Once Goose is connected, it can use
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+Connection only makes those tools available. Load [`TOOLS.md`](TOOLS.md) as Goose instructions as
+well so the agent checks before taking a side effectful action.
+
+## Configure the MCP extension
+
+Goose reads its main configuration from `~/.config/goose/config.yaml` on macOS and Linux, or
+`%APPDATA%\Block\goose\config\config.yaml` on Windows, as described in its [configuration
+guide](https://github.com/aaif-goose/goose/blob/main/documentation/docs/guides/config-files.md).
+Add the following entry under the existing top-level `extensions` key:
+
+```yaml
+extensions:
+  gnt-brain:
+    type: streamable_http
+    name: gnt-brain
+    enabled: true
+    uri: "https://api.gntai.dev/mcp/"
+    headers:
+      Authorization: "Bearer ${GNT_MCP_KEY}"
+    env_keys:
+      - GNT_MCP_KEY
+    envs: {}
+    timeout: 300
+```
+
+Keep the trailing slash in the MCP URL. Goose resolves each name in `env_keys` from the matching
+environment variable first and from its secret storage as a fallback. It then substitutes the
+resolved value in the URI and headers, so the credential does not need to be stored in
+`config.yaml`.
+This behavior is implemented in Goose's [extension manager](https://github.com/aaif-goose/goose/blob/main/crates/goose/src/agents/extension_manager.rs#L538-L611).
+
+Create a key with `gnt keys create`, or use an existing key from `gnt keys list`. To use the shell
+environment as the secret source, make the key available to the process that starts Goose:
+
+```bash
+export GNT_MCP_KEY="gnt_live_..."
+```
+
+Do not commit the key or paste it into `config.yaml`, a project hint file, an issue, or a log. If
+Goose is launched by its desktop app, make sure `GNT_MCP_KEY` is available to the app process, or
+use Goose's configured secret storage for `env_keys` instead of putting the value in the
+configuration file.
+
+## Load the action policy
+
+Goose loads project context from `.goosehints`. Add the contents of [`TOOLS.md`](TOOLS.md) to the
+project's `.goosehints` file, or reference the file with Goose's `@` syntax:
+
+```text
+@path/to/integrations/goose/TOOLS.md
+```
+
+For a guardrail that is injected on every turn, point Goose's [persistent-instructions
+setting](https://github.com/aaif-goose/goose/blob/main/documentation/docs/guides/context-engineering/using-persistent-instructions.md)
+at this file:
+
+```bash
+# Run this from the gnt checkout, or replace $PWD with the file's absolute path.
+export GOOSE_MOIM_MESSAGE_FILE="$PWD/integrations/goose/TOOLS.md"
+```
+
+The persistent-instructions option is useful when the `check_action` requirement should be
+injected on every turn. If Goose is launched from its desktop app, make sure these environment
+variables are available to the app process, or use `.goosehints` instead.
+
+## Verify the connection
+
+Start a new Goose session after changing `config.yaml`. Confirm that the `gnt-brain` extension is
+enabled and that its tools are listed. Before asking Goose to perform an action with an external
+side effect, verify that it calls `check_action` first and follows the returned verdict. A missing
+or unclear verdict is not permission to continue.
+
+If the extension does not load, check the YAML indentation and confirm that `GNT_MCP_KEY` is set in
+the environment inherited by Goose. Do not put the raw key in a bug report while troubleshooting.

--- a/integrations/goose/CONNECT.md
+++ b/integrations/goose/CONNECT.md
@@ -25,6 +25,12 @@ extensions:
       - GNT_MCP_KEY
     envs: {}
     timeout: 300
+    available_tools:
+      - check_action
+      - search_rules
+      - get_rule
+      - list_skill_packs
+      - get_skill_pack
 ```
 
 Keep the trailing slash in the MCP URL. Goose resolves each name in `env_keys` from the matching
@@ -38,6 +44,18 @@ environment as the secret source, make the key available to the process that sta
 
 ```bash
 export GNT_MCP_KEY="gnt_live_..."
+```
+
+PowerShell:
+
+```powershell
+$env:GNT_MCP_KEY = "gnt_live_..."
+```
+
+Command Prompt (`cmd.exe`):
+
+```bat
+set "GNT_MCP_KEY=gnt_live_..."
 ```
 
 Do not commit the key or paste it into `config.yaml`, a project hint file, an issue, or a log. If
@@ -63,6 +81,18 @@ at this file:
 export GOOSE_MOIM_MESSAGE_FILE="$PWD/integrations/goose/TOOLS.md"
 ```
 
+PowerShell:
+
+```powershell
+$env:GOOSE_MOIM_MESSAGE_FILE = Join-Path $PWD "integrations/goose/TOOLS.md"
+```
+
+Command Prompt (`cmd.exe`):
+
+```bat
+set "GOOSE_MOIM_MESSAGE_FILE=%CD%\integrations\goose\TOOLS.md"
+```
+
 The persistent-instructions option is useful when the `check_action` requirement should be
 injected on every turn. If Goose is launched from its desktop app, make sure these environment
 variables are available to the app process, or use `.goosehints` instead.
@@ -74,5 +104,7 @@ enabled and that its tools are listed. Before asking Goose to perform an action 
 side effect, verify that it calls `check_action` first and follows the returned verdict. A missing
 or unclear verdict is not permission to continue.
 
-If the extension does not load, check the YAML indentation and confirm that `GNT_MCP_KEY` is set in
-the environment inherited by Goose. Do not put the raw key in a bug report while troubleshooting.
+If the extension does not load, check the YAML indentation and confirm that `GNT_MCP_KEY` is available
+either in the environment inherited by Goose or in Goose's configured secret storage. Goose checks the
+inherited environment first, then falls back to secret storage for names listed under `env_keys`. Do not
+put the raw key in a bug report while troubleshooting.

--- a/integrations/goose/TOOLS.md
+++ b/integrations/goose/TOOLS.md
@@ -11,6 +11,12 @@ gnt-brain exposes `check_action`, `search_rules`, `get_rule`, `list_skill_packs`
 Before any action that sends a message, moves money, deletes data, or is otherwise hard to undo,
 call `check_action` first with a plain-English description of what you are about to do.
 
+This file is an instruction for Goose; it is not an enforcement boundary by itself. The client or
+action executor that performs the side effect must reject a call without an `allowed` verdict for
+the exact action. Bind that approval to the recipient, amount, target, and scope, and run a fresh
+check if any of those details change. Never reuse a verdict from a different action or an earlier
+request.
+
 - If the verdict is `allowed`, proceed with the action.
 - If the verdict is `blocked`, do not proceed. Tell the user why and cite the rule returned by
   gnt-brain.

--- a/integrations/goose/TOOLS.md
+++ b/integrations/goose/TOOLS.md
@@ -1,0 +1,34 @@
+# gnt-brain tools
+
+This file is intended to be loaded by Goose as project hints or persistent instructions. The MCP
+connection itself is configured separately; see [`CONNECT.md`](CONNECT.md).
+
+gnt-brain exposes `check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and
+`get_skill_pack`.
+
+## Before you act
+
+Before any action that sends a message, moves money, deletes data, or is otherwise hard to undo,
+call `check_action` first with a plain-English description of what you are about to do.
+
+- If the verdict is `allowed`, proceed with the action.
+- If the verdict is `blocked`, do not proceed. Tell the user why and cite the rule returned by
+  gnt-brain.
+- If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+Never treat a missing, failed, or unclear verdict as permission to act.
+
+## Before answering a policy question
+
+Use `search_rules` to find the organization's approved rules. Use `get_rule` to retrieve a rule by
+ID when more detail is needed. Only approved rules are returned; do not infer policy from drafts,
+rules in review, rejected rules, or deprecated rules.
+
+Use `list_skill_packs` and `get_skill_pack` for the organization's compiled context instead of
+guessing at company policy.
+
+## When a human is needed
+
+On a `needs_human` verdict, stop. Do not retry with a softer description, route around the check,
+or choose a branch on the human's behalf. Surface the proposed action and gnt-brain's reason, then
+wait for the human's decision.


### PR DESCRIPTION
## What & why

Closes #81.

Add a Goose integration guide for gnt-brain’s remote MCP extension, including the current `streamable_http` config shape, `env_keys` secret handling, and Goose’s `.goosehints` / persistent-instructions options. The companion `TOOLS.md` carries the existing `check_action`-first policy so connecting the tools also documents when an agent must stop for a human verdict.

## Test plan

- Checked the extension fields against Goose’s current configuration guide and extension manager source.
- Ran documentation assertions for the config path, transport, secret placeholder, persistent-instructions setting, and all five gnt-brain tools.
- Ran `git diff --check`; no credential-like literal was present.
- Documentation-only change; no runtime test suite is applicable.
- AI assistance: I used AI assistance to research the current Goose configuration contract and draft the documentation, then reviewed the final diff and ran the checks above.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: the documentation was checked against Goose’s current configuration and source.
- [x] No dead code — this is a documentation-only change.
- [x] Non-trivial logic (a new branch, a parser, anything security- or money-adjacent) has a test. A one-line change doesn’t need one; a new code path does not apply here.
- [x] If this touches anything multi-tenant (rules, connectors, MCP keys, billing), it respects org/tenant isolation — this only documents an existing remote MCP connection and keeps the key out of the repo.
- [x] Matches this repo’s existing patterns, following `integrations/openclaw/`.
- [ ] If this touches `apps/cli/src/prebrain/extraction/`, the PR description includes the recall/precision numbers from `bun run eval:extraction -- --mode cloud`. (Not applicable.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for connecting Goose to gnt-brain through a streamable HTTP MCP extension.
  * Documented secure API key configuration, credential handling, and connection verification.
  * Added guidance for loading project-specific tool instructions.
  * Documented authorization checks and how to handle blocked, unclear, or approval-required actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->