### PR TITLE
drop the broken apps/store dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,16 +22,12 @@ updates:
           - "minor"
           - "patch"
 
-  - package-ecosystem: "npm"
-    directory: "/apps/store"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
+  # apps/store is bun-native (its own bun.lock, excluded from the pnpm
+  # workspace) -- Dependabot has no "bun" ecosystem, so an "npm" entry here
+  # bumps package.json but can't regenerate bun.lock, which breaks CI on
+  # every PR it opens (frozen-lockfile mismatch, e.g. #134). Removed rather
+  # than pointed at an ecosystem that doesn't exist; deps here stay on
+  # manual `bun update` until Dependabot ships Bun support.
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
apps/store runs on bun (its own bun.lock, deliberately kept out of the pnpm workspace). Dependabot has no bun ecosystem, so the npm entry pointed at /apps/store could bump package.json but never touch bun.lock -- every PR it opened (#134, and #137 via the root entry cross-touching apps/store's package.json) failed CI on `bun install --frozen-lockfile`, and I had to hand-fix both lockfiles to get them merged.

Removing the dedicated entry stops the guaranteed-broken half of this. The root `/` npm entry can still occasionally touch apps/store/package.json on a shared dependency name (that's what happened with #137) since Dependabot doesn't seem to honor pnpm-workspace.yaml's `!apps/store` exclusion -- if that happens again it needs the same manual `bun install` + push fix. apps/store deps are on manual `bun update` for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to reflect the app’s manual maintenance requirements.
  * Added documentation clarifying why automated dependency updates are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->