### PR TITLE
test(cli): cover theme.ts formatting helpers

### DIFF
--- a/apps/cli/test/theme.test.ts
+++ b/apps/cli/test/theme.test.ts
@@ -48,9 +48,12 @@ test("box draws a fixed-width frame around its lines", () => {
 });
 
 test("box pads by visible width, so ANSI colors don't throw off alignment", () => {
-  // success("a") is a 1-char string wrapped in escape codes; a length-based
-  // pad would see ~20 chars and add nothing, visibly misaligning the box.
-  const frame = box([success("a")], 4).split("\n");
+  // Hand-built ANSI string instead of success("a"): chalk disables colors
+  // when stdout isn't a TTY (bun test), so the codes would silently vanish
+  // and the test would pass even with a length-based pad.
+  const colored = "\x1b[38;2;0;255;133ma\x1b[39m";
+  expect(colored.length).toBeGreaterThan(1); // raw length must exceed visible length
+  const frame = box([colored], 4).split("\n");
   expect(frame.map(plain)).toEqual(["┌──────┐", "│ a    │", "└──────┘"]);
 });
 

--- a/apps/cli/test/theme.test.ts
+++ b/apps/cli/test/theme.test.ts
@@ -1,0 +1,75 @@
+// Coverage for theme.ts's pure formatting helpers -- every boxed or wrapped
+// line in the CLI goes through these, and the ANSI-aware padding
+// (visibleLength vs raw string length) is exactly the kind of thing a
+// missing test lets silently regress.
+import { expect, test } from "bun:test";
+import { box, confidenceColor, error, keyValueLines, muted, success, wrapText } from "../src/theme.js";
+
+// eslint-disable-next-line no-control-regex -- test assertions compare visible CLI output
+const ANSI = /\x1b\[[0-9;]*m/g;
+const plain = (s: string): string => s.replace(ANSI, "");
+
+test("wrapText wraps a sentence onto lines no wider than the width", () => {
+  expect(wrapText("the quick brown fox", 10)).toEqual(["the quick", "brown fox"]);
+});
+
+test("wrapText keeps a word that exactly fills the line on its own line", () => {
+  expect(wrapText("ab cd", 2)).toEqual(["ab", "cd"]);
+});
+
+test("wrapText hard-chunks a single token longer than the width", () => {
+  expect(wrapText("abcdefghij", 4)).toEqual(["abcd", "efgh", "ij"]);
+});
+
+test("wrapText flushes the current line before hard-chunking", () => {
+  expect(wrapText("ab abcdefgh", 4)).toEqual(["ab", "abcd", "efgh"]);
+});
+
+test("wrapText preserves embedded newlines as blank lines", () => {
+  expect(wrapText("a\n\nb", 5)).toEqual(["a", "", "b"]);
+});
+
+test("keyValueLines pads values into a column aligned on the longest label", () => {
+  const lines = keyValueLines([
+    ["a", "1"],
+    ["bb", "2"],
+    ["ccc", "3"],
+  ]);
+  expect(lines.map(plain)).toEqual(["a:   1", "bb:  2", "ccc: 3"]);
+});
+
+test("keyValueLines returns no lines for no rows", () => {
+  expect(keyValueLines([])).toEqual([]);
+});
+
+test("box draws a fixed-width frame around its lines", () => {
+  const frame = box(["hi"], 2).split("\n");
+  expect(frame.map(plain)).toEqual(["┌────┐", "│ hi │", "└────┘"]);
+});
+
+test("box pads by visible width, so ANSI colors don't throw off alignment", () => {
+  // success("a") is a 1-char string wrapped in escape codes; a length-based
+  // pad would see ~20 chars and add nothing, visibly misaligning the box.
+  const frame = box([success("a")], 4).split("\n");
+  expect(frame.map(plain)).toEqual(["┌──────┐", "│ a    │", "└──────┘"]);
+});
+
+test("box leaves an over-width line unpadded instead of truncating it", () => {
+  const frame = box(["toolong", "ok"], 4).split("\n");
+  expect(frame.map(plain)).toEqual(["┌──────┐", "│ toolong │", "│ ok   │", "└──────┘"]);
+});
+
+test("confidenceColor uses the success color at and above 0.8", () => {
+  expect(confidenceColor(1.0)).toBe(success);
+  expect(confidenceColor(0.8)).toBe(success);
+});
+
+test("confidenceColor uses muted between 0.5 and 0.8", () => {
+  expect(confidenceColor(0.799)).toBe(muted);
+  expect(confidenceColor(0.5)).toBe(muted);
+});
+
+test("confidenceColor uses the error color below 0.5", () => {
+  expect(confidenceColor(0.499)).toBe(error);
+  expect(confidenceColor(0)).toBe(error);
+});


### PR DESCRIPTION
## What & why

Closes #154.

`apps/cli/src/theme.ts` had zero tests even though it's the one module every boxed/wrapped line in the CLI passes through. The interesting bits were all untested edge cases:

- `wrapText` hard-chunking a single token longer than the width (a URL or hash), flushing the current line first, and preserving embedded newlines as blank lines
- `keyValueLines` column alignment as label lengths vary
- `box` padding by *visible* width so ANSI-colored strings don't misalign the frame, and leaving over-width lines alone instead of truncating
- `confidenceColor` boundary behavior at 0.8 / 0.5

## Test plan

```
$ bun test test/theme.test.ts
 13 pass
 0 fail
Ran 13 tests across 1 file.
```

Also ran the full `apps/cli` suite (863 pass, 7 fail) — the 7 failures are pre-existing zip/permissions tests that fail identically without this change on this machine (they pass in CI's Linux runner). `tsc --noEmit` and `eslint test/theme.test.ts` are both clean.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: the new tests pass locally via `bun test`.
- [x] No dead code — nothing unused added.
- [x] Non-trivial logic has a test: the whole point of this change is adding those tests.
- [x] Matches this repo's existing test patterns (`bun:test`, `.js` import suffixes, the same `stripAnsi` helper other tests use).
- [x] No multi-tenant surface touched.
- [x] Not an extraction change, so the recall/precision item doesn't apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for command-line theme formatting, including text wrapping, newline handling, key/value alignment, box rendering, ANSI-colored text, and oversized lines.
  - Added validation for confidence-color threshold behavior.
  - These improvements help ensure consistent and reliable formatting across a wider range of terminal output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->