### PR TITLE
fix(cli): wrap long rule titles inside the review box

### DIFF
--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -95,7 +95,7 @@ export function boxWidth(): number {
 
 type Message = { kind: "ok" | "error"; text: string } | null;
 
-function render(rules: Rule[], index: number, message: Message): void {
+export function render(rules: Rule[], index: number, message: Message): void {
   console.clear();
   const rule = rules[index];
   const width = boxWidth();
@@ -103,7 +103,10 @@ function render(rules: Rule[], index: number, message: Message): void {
   const lines: string[] = [];
   lines.push(muted(`[${index + 1}/${rules.length}] in review · v${rule.version}`));
   lines.push("");
-  lines.push(bold(rule.title));
+  // Same wrap-as-you-push treatment the body gets below: titles are capped
+  // at 200 chars by the lint/server but the box is at most 76 wide, and
+  // box() only pads short lines -- it doesn't wrap long ones.
+  lines.push(...wrapText(rule.title, width).map((line) => bold(line)));
   lines.push(...wrapText(rule.body, width).map((line) => text(line)));
   lines.push("");
   const confidencePct = `${Math.round(rule.confidence * 100)}%`;

--- a/apps/cli/test/review.test.ts
+++ b/apps/cli/test/review.test.ts
@@ -13,7 +13,7 @@ const testConfigDir = mkdtempSync(join(tmpdir(), "gnt-review-test-"));
 process.env.GNT_CONFIG_DIR = testConfigDir;
 
 const { saveApiKey } = await import("../src/credentials.js");
-const { describeErrorDetail, fetchPending, actOnRule, boxWidth, review } = await import(
+const { describeErrorDetail, fetchPending, actOnRule, boxWidth, render, review } = await import(
   "../src/commands/review.js"
 );
 
@@ -167,6 +167,41 @@ test("boxWidth: a terminal narrower than MIN_BOX_WIDTH returns the available wid
 test("boxWidth: columns undefined falls back to treating the terminal as 80 columns wide", () => {
   Object.defineProperty(process.stdout, "columns", { value: undefined, configurable: true });
   expect(boxWidth()).toBe(76);
+});
+
+// Strips chalk's ANSI escapes the way theme.ts's own visibleLength does,
+// so box line widths can be measured on the raw render() output.
+// eslint-disable-next-line no-control-regex -- same escape-stripping pattern theme.ts uses
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+test("render: a rule title wider than the box wraps inside it instead of overflowing", () => {
+  Object.defineProperty(process.stdout, "columns", { value: 80, configurable: true });
+  // @ts-expect-error -- stubbing console.clear for the render test
+  console.clear = mock(() => {});
+
+  const longTitle = "A very long rule title ".repeat(10);
+  const rules = [{ id: "r1", title: longTitle, body: "short body", confidence: 0.8, tags: [], version: 1 }];
+  render(rules, 0, null);
+
+  const width = boxWidth();
+  const boxTotalWidth = width + 4; // border + padding on each side
+  const renderedLines = logs.join("\n").split("\n").map((line) => line.replace(ANSI_PATTERN, ""));
+  expect(renderedLines.length).toBeGreaterThan(1);
+  for (const line of renderedLines) {
+    expect(line.length).toBeLessThanOrEqual(boxTotalWidth);
+  }
+});
+
+test("render: a short title stays on one line", () => {
+  Object.defineProperty(process.stdout, "columns", { value: 80, configurable: true });
+  // @ts-expect-error -- stubbing console.clear for the render test
+  console.clear = mock(() => {});
+
+  const rules = [{ id: "r1", title: "Refund window", body: "...", confidence: 0.8, tags: [], version: 1 }];
+  render(rules, 0, null);
+
+  const renderedLines = logs.join("\n").split("\n").map((line) => line.replace(ANSI_PATTERN, ""));
+  expect(renderedLines.filter((line) => line.includes("Refund window"))).toHaveLength(1);
 });
 
 test("review(): zero pending rules prints a message and returns without touching stdin", async () => {


### PR DESCRIPTION
## What & why

`gnt review` shows each rule inside a fixed-width box. The body was already
wrapped to fit, but the title went in raw — and titles are allowed to be up
to 200 chars while the box never gets wider than 76 columns, so a long
title blew out the right border and made that rule's screen a mess. This
wraps the title with the same `wrapText` the body already uses.

## Test plan

Added two tests around `render()` (previously the one uncovered part of
review.ts):

- a title wider than the box wraps so every rendered line stays inside it
- a short title still renders on a single line

`bun test test/review.test.ts` → 17 passing. `pnpm run lint`, `pnpm run
typecheck`, and `pnpm run build` are all clean.

- [x] Commits are signed off (`git commit -s`)
- [x] Functionally correct: you ran this, not just read it
- [x] Non-trivial logic (a new branch, a parser, anything security- or
      money-adjacent) has a test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long review rule titles now wrap within the available display width instead of extending beyond the review box.
  * Short titles continue to display on a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->