### PR TITLE
docs: fix stale apps/web references and MCP tool count

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ assignees: ""
 
 ## Which part of gnt
 
-- [ ] apps/web (marketing site / docs)
+- [ ] apps/docs (marketing site / docs)
 - [ ] apps/api (rules pipeline, GitHub webhook, MCP server, connectors)
 - [ ] apps/cli (`gnt` command)
 - [ ] apps/store (rules storage, approval gate)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,7 @@ actionable.
 
 ## Which part of gnt this touches
 
-- [ ] apps/web (marketing site / docs)
+- [ ] apps/docs (marketing site / docs)
 - [ ] apps/api (rules pipeline, GitHub webhook, MCP server, connectors)
 - [ ] apps/cli (`gnt` command)
 - [ ] apps/store (rules storage, approval gate)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,7 +55,7 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      # Covers apps/web + apps/cli, the pnpm workspace (pnpm-workspace.yaml).
+      # Covers apps/cli + apps/docs, the pnpm workspace (pnpm-workspace.yaml).
       # apps/store is deliberately excluded from it (Bun-native, own
       # lockfile — see that file's comment) and audited separately below.
       - run: pnpm install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ brings up all of it plus Postgres and Redis in one shot.
 ## Test and lint
 
 ```bash
-pnpm turbo run lint typecheck build test   # web + cli, via turbo
+pnpm turbo run lint typecheck build test   # cli + docs, via turbo
 ```
 
 ```bash

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -45,11 +45,13 @@ Needs a running Postgres and Redis (`REDIS_URL`/`DATABASE_URL`) — see the repo
 - **MCP server** (`mcp_server/`) — mounted at `/mcp`. This is the one
   published, customer-facing, agent-facing MCP surface (a founder decision)
   — `settings.mcp_url` is the source-of-truth URL, echoed
-  in the CLI (`gnt keys create`) and the docs site. Four tools, all reading
+  in the CLI (`gnt keys create`) and the docs site. Five tools, all reading
   from the git-native rules store: `search_rules`, `get_rule`,
-  `list_skill_packs`, `get_skill_pack`. apps/store doesn't run an MCP
-  server at all anymore — it's purely an internal HTTP service this router
-  set talks to (see `apps/store/README.md`).
+  `check_action` (a compliance verdict — allowed/blocked/needs_human —
+  before an agent takes a side-effectful action), `list_skill_packs`,
+  `get_skill_pack`. apps/store doesn't run an MCP server at all anymore —
+  it's purely an internal HTTP service this router set talks to (see
+  `apps/store/README.md`).
 
   A separate, older knowledge-unit pipeline (`capture`, `list_topics`,
   `get_skill`, `search_knowledge`, `ask_brain` — triage/extract/embed via


### PR DESCRIPTION
## What & why

Three small doc corrections, each pointing at something that's now wrong in the repo:

- The issue templates list **apps/web** as a component, but the repo has no `apps/web` — the docs site lives in `apps/docs`. Same stale reference in `CONTRIBUTING.md`'s turbo comment ("web + cli") and the audit workflow's comment, both of which now say cli + docs.
- `apps/api/README.md` says the MCP server has four tools and lists four of them — `server.py` actually registers five. `check_action` was missing from the list (it's the compliance-verdict tool, pre-flight check before an agent acts).

## Test plan

Docs/comment-only change. The tool count was verified against `@mcp.tool()` registrations in `apps/api/src/gnt/mcp_server/server.py` (five: `search_rules`, `get_rule`, `check_action`, `list_skill_packs`, `get_skill_pack`); the workspace membership against `pnpm-workspace.yaml` (apps/cli + apps/docs, store excluded).

- [x] Commits are signed off (`git commit -s`)
- [x] Functionally correct: you ran this, not just read it
