### PR TITLE
docs: fix stale apps/web references in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ assignees: ""
 
 ## Which part of gnt
 
-- [ ] apps/web (marketing site / docs)
+- [ ] apps/docs (documentation site)
 - [ ] apps/api (rules pipeline, GitHub webhook, MCP server, connectors)
 - [ ] apps/cli (`gnt` command)
 - [ ] apps/store (rules storage, approval gate)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,7 @@ actionable.
 
 ## Which part of gnt this touches
 
-- [ ] apps/web (marketing site / docs)
+- [ ] apps/docs (documentation site)
 - [ ] apps/api (rules pipeline, GitHub webhook, MCP server, connectors)
 - [ ] apps/cli (`gnt` command)
 - [ ] apps/store (rules storage, approval gate)


### PR DESCRIPTION
## What & why

Closes #161.

Both issue templates list `apps/web` as a checklist area, but this repo has no `apps/web` directory — the docs site is `apps/docs`, and the OSS repo only ships `apps/api`, `apps/cli`, `apps/docs`, `apps/store`. (`.github/workflows/security.yml` even notes the marketing site "doesn't ship in this repo at all".)

So every bug report / feature request filed today has a checkbox nobody can ever tick. This swaps the stale entry for `apps/docs`, matching the actual layout.

## Test plan

Docs-only change (two lines in `.github/ISSUE_TEMPLATE/`). Verified there's no `apps/web` directory in the repo and that `apps/docs` is the docs app:

```
$ ls apps
api  cli  docs  store
```

No runtime test suite applies.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: the checkboxes now match the repo layout.
- [x] No dead code — two-line doc edit.
- [x] Non-trivial logic — N/A, documentation-only.
- [x] No multi-tenant surface touched.
- [x] Not an extraction change, so the recall/precision item doesn't apply.
