### PR TITLE
test(cli): cover help.ts formatting helpers

### DIFF
--- a/apps/cli/test/help.test.ts
+++ b/apps/cli/test/help.test.ts
@@ -1,0 +1,108 @@
+// Coverage for help.ts's custom Commander formatter: the branded header,
+// the section layout (ARGUMENTS / COMMANDS / OPTIONS), and the
+// prebrain-only grouped-options path -- 60+ connector flags become
+// unreadable as one flat list, so anything that breaks the grouping or
+// the ordering quietly regresses the one surface every user sees.
+import { Command } from "commander";
+import { expect, test } from "bun:test";
+import { formatHelp } from "../src/help.js";
+
+// eslint-disable-next-line no-control-regex -- test assertions compare visible CLI output
+const ANSI = /\x1b\[[0-9;]*m/g;
+const plain = (s: string): string => s.replace(ANSI, "");
+// formatHelp always ends with a newline, so drop the empty trailing element.
+const lines = (cmd: Command): string[] => plain(formatHelp(cmd, cmd.createHelp())).split("\n").slice(0, -1);
+
+// Rows under a section header, stopping at the blank line that precedes the
+// next all-caps section header (OPTIONS is the last section, so it runs to
+// the end of the output).
+function section(cmd: Command, header: string): string[] {
+  const out = lines(cmd);
+  const start = out.indexOf(header);
+  if (start < 0) return [];
+  const rest = out.slice(start + 1);
+  const end = rest.findIndex((line, i) => line === "" && /^[A-Z]+$/.test(rest[i + 1] ?? ""));
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+test("formatHelp renders the branded header, description, and usage", () => {
+  const cmd = new Command().name("gnt").description("The gnt CLI");
+  const out = lines(cmd);
+  expect(out[0]).toBe("[ gnt.ai ]");
+  expect(out[1]).toBe("The gnt CLI");
+  expect(out[3]).toBe("Usage: gnt [options]");
+});
+
+test("formatHelp omits ARGUMENTS and COMMANDS sections when there is nothing to show", () => {
+  const cmd = new Command().name("gnt");
+  const out = lines(cmd).join("\n");
+  expect(out).not.toContain("ARGUMENTS");
+  expect(out).not.toContain("COMMANDS");
+  expect(out).toContain("OPTIONS"); // -h, --help is always present
+});
+
+test("formatHelp aligns ARGUMENTS rows on the longest argument term", () => {
+  const cmd = new Command()
+    .name("gnt")
+    .argument("<first>", "short")
+    .argument("<much-longer-name>", "longer");
+  expect(section(cmd, "ARGUMENTS")).toEqual([
+    "  first             short",
+    "  much-longer-name  longer",
+  ]);
+});
+
+test("formatHelp lists COMMANDS with the auto-added help command aligned last", () => {
+  const cmd = new Command()
+    .name("gnt")
+    .addCommand(new Command().name("one").description("first command"))
+    .addCommand(new Command().name("two").description("second command"));
+  expect(section(cmd, "COMMANDS")).toEqual([
+    "  one             first command",
+    "  two             second command",
+    "  help [command]  display help for command",
+  ]);
+});
+
+test("formatHelp renders a description-less option without the padded description column", () => {
+  const cmd = new Command().name("gnt").option("-q, --quiet");
+  expect(section(cmd, "OPTIONS")).toEqual([
+    "  -q, --quiet",
+    "  -h, --help   display help for command",
+  ]);
+});
+
+test("formatHelp keeps a flat aligned OPTIONS list until the prebrain threshold", () => {
+  const cmd = new Command().name("gnt");
+  for (let i = 0; i < 5; i++) cmd.option(`--flag-${i} <value>`, `flag ${i}`);
+  const options = section(cmd, "OPTIONS");
+  expect(options).toEqual([
+    "  --flag-0 <value>  flag 0",
+    "  --flag-1 <value>  flag 1",
+    "  --flag-2 <value>  flag 2",
+    "  --flag-3 <value>  flag 3",
+    "  --flag-4 <value>  flag 4",
+    "  -h, --help        display help for command",
+  ]);
+});
+
+test("formatHelp groups prebrain-style options by connector when there are more than 15", () => {
+  const cmd = new Command().name("gnt prebrain");
+  cmd.option("--all", "run all connectors");
+  for (let i = 0; i < 12; i++) cmd.option(`--generic-${i}`, `generic option ${i}`);
+  cmd.option("--mcp-notion <token>", "Notion MCP token");
+  cmd.option("--mcp-jira <token>", "Jira MCP token");
+  const options = section(cmd, "OPTIONS");
+  // General options (everything not matching a connector keyword) come first,
+  // in declaration order with the auto-added -h, --help row last.
+  expect(options[0]).toBe("  --all         run all connectors");
+  expect(options[options.length - 1]).toBe("  --mcp-jira <token>  Jira MCP token");
+  // Connector groups render in PREBRAIN_OPTION_GROUPS order with their headers.
+  const notion = options.indexOf("  Notion");
+  const jira = options.indexOf("  Jira");
+  expect(notion).toBeGreaterThan(-1);
+  expect(jira).toBeGreaterThan(notion);
+  expect(options[notion + 1]).toBe("  --mcp-notion <token>  Notion MCP token");
+  // The general bucket is separated from the groups by a blank line.
+  expect(options[notion - 1]).toBe("");
+});


### PR DESCRIPTION
## What & why

Closes #153.

`apps/cli/src/help.ts` had zero tests even though `formatHelp` is wired into the root program via `configureHelp`, so every subcommand's `--help` output goes through it. The interesting behaviors were all untested:

- the branded `[ gnt.ai ]` header and the ARGUMENTS / COMMANDS / OPTIONS section layout, including sections that should be omitted when there is nothing to show
- term/description column alignment as term lengths vary, including description-less options
- the prebrain-only grouped-options path (16+ flags): general flags first, then connector flags under their `PREBRAIN_OPTION_GROUPS` headers in order

## Test plan

```
$ bun test test/help.test.ts
 7 pass
 0 fail
Ran 7 tests across 1 file.
```

Also ran the full `apps/cli` suite (857 pass, 1 skip, 7 fail) — the 7 failures are pre-existing zip/permissions tests that fail identically without this change on this machine (they pass in CI's Linux runner). `tsc --noEmit` and `eslint` are both clean.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: the new tests pass locally via `bun test`.
- [x] No dead code — nothing unused added.
- [x] Non-trivial logic has a test: this PR *is* the tests, covering every branch of the formatter (flat vs grouped options, description-less rows, section omission).
- [x] Matches this repo's existing patterns — same structure as `test/theme.test.ts`.
