### PR TITLE
ci: keep fork JavaScript checks from timing out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,17 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # apps/cli's own test script is `bun test` (its privacy-gate suite,
-      # including the eval/privacy-gate quality gate, needs bun:test). bun
-      # reads the node_modules pnpm already installed above; no separate
-      # `bun install` needed.
+      # including the eval/privacy-gate quality gate, needs bun:test). Bun
+      # 1.3.14 can deadlock in bun:test on Linux x64 and remain alive after
+      # the test timeout (https://github.com/oven-sh/bun/issues/37189).
+      # Keep this job on the reported last-good release until that regression
+      # is fixed. Bun reads the node_modules pnpm installed above, so this job
+      # does not need a separate `bun install`.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.14
+          bun-version: 1.3.13
 
-      # Keep task types in separate steps. The previous combined invocation
-      # left the TypeScript, ESLint, and Bun processes alive until the job
-      # timeout on GitHub's 20260810.271.1 hosted image. Separate steps avoid
-      # that invocation shape and make any future stall identify the exact
+      # Keep task types in separate steps so a future stall names the exact
       # check. Run all three small workspaces so a workflow-only PR exercises
       # this job instead of reporting success with zero affected tasks.
       - name: Lint JavaScript workspaces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      # fetch-depth: 0 (full history, not just the last commit) -- turbo's
-      # --affected below needs to walk back to the PR's merge base (or the
-      # previous commit on push-to-main) to diff changed files. A shallow
-      # clone doesn't break this, turbo just falls back to treating
-      # everything as affected, but that silently defeats the point of this
-      # job, so pay for full history instead of finding out from a
-      # suspiciously-full CI run.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
-        with:
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
@@ -52,36 +43,23 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      # turbo's own GITHUB_BASE_REF auto-detection resolves to a bare branch
-      # name ("main"), which doesn't exist as a local ref in this checkout --
-      # only origin/main does -- so it fails to resolve and silently falls
-      # back to treating every package as affected (safe, but defeats the
-      # point). Set TURBO_SCM_BASE explicitly instead of trusting the
-      # auto-detect: origin/<base branch> for a PR, the pre-push commit for
-      # a push to main, origin/main for anything else (e.g. a manual
-      # workflow_dispatch run).
-      - name: Resolve turbo affected base
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            base="origin/${{ github.event.pull_request.base.ref }}"
-          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            base="${{ github.event.before }}"
-          else
-            base="origin/main"
-          fi
-          echo "TURBO_SCM_BASE=$base" >> "$GITHUB_ENV"
+      # Keep task types in separate steps. The previous combined invocation
+      # left the TypeScript, ESLint, and Bun processes alive until the job
+      # timeout on GitHub's 20260810.271.1 hosted image. Separate steps avoid
+      # that invocation shape and make any future stall identify the exact
+      # check. Run all three small workspaces so a workflow-only PR exercises
+      # this job instead of reporting success with zero affected tasks.
+      - name: Lint JavaScript workspaces
+        run: pnpm turbo run lint
 
-      # --affected scopes this to packages actually touched by the diff
-      # (base set above, head defaults to this checkout's HEAD). A change to
-      # a package's own dependency closure (root lockfile, a shared package
-      # it imports) still marks it affected, so a broad diff still gets the
-      # full check -- this only narrows work for diffs that are genuinely
-      # narrow. One combined invocation, not four: turbo already schedules
-      # lint/typecheck/build/test concurrently across the task graph, so
-      # splitting into separate steps or jobs here would only add
-      # checkout/install overhead per job without shortening the actual
-      # critical path.
-      - run: pnpm turbo run lint typecheck build test --affected
+      - name: Typecheck JavaScript workspaces
+        run: pnpm turbo run typecheck
+
+      - name: Build JavaScript workspaces
+        run: pnpm turbo run build
+
+      - name: Test JavaScript workspaces
+        run: pnpm turbo run test
 
   clean-install:
     name: clean install (no secrets, from scratch)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # apps/cli's own test script is `bun test` (its privacy-gate suite,
-      # including the eval/privacy-gate quality gate, needs bun:test). Bun
-      # 1.3.14 can deadlock in bun:test on Linux x64 and remain alive after
-      # the test timeout (https://github.com/oven-sh/bun/issues/37189).
-      # Keep this job on the reported last-good release until that regression
-      # is fixed. Bun reads the node_modules pnpm installed above, so this job
-      # does not need a separate `bun install`.
+      # apps/cli's tests need bun:test. Bun reads the node_modules pnpm
+      # installed above, so this job does not need a separate `bun install`.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       # Keep task types in separate steps so a future stall names the exact
       # check. Run all three small workspaces so a workflow-only PR exercises
@@ -58,8 +53,22 @@ jobs:
       - name: Build JavaScript workspaces
         run: pnpm turbo run build
 
-      - name: Test JavaScript workspaces
-        run: pnpm turbo run test
+      - name: Test JavaScript examples
+        run: pnpm --filter @gnt-ai/examples test
+
+      # On the current GitHub-hosted Linux image, one Bun process discovering
+      # all 79 CLI test files can stay alive before it prints a file or result.
+      # A fresh process per file avoids shared loader and mock state, and
+      # leaves the exact file visible if a future runner stalls.
+      - name: Test CLI files
+        working-directory: apps/cli
+        run: |
+          set -euo pipefail
+          while IFS= read -r test_file; do
+            echo "::group::bun test $test_file"
+            bun test "$test_file"
+            echo "::endgroup::"
+          done < <(find test -type f -name '*.test.ts' | sort)
 
   clean-install:
     name: clean install (no secrets, from scratch)

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -11,11 +11,10 @@ Both also support `workflow_dispatch` for a manual run.
 
 **`ci.yml`**
 
-- `js` — lint, typecheck, build, test for the pnpm workspace (`apps/cli`, `apps/docs`, and
-  everything under `packages/`), via `pnpm turbo run lint typecheck build test --affected`.
-  `--affected` scopes the run to packages actually touched by the diff (or everything, if the
-  diff touches a shared dependency like the root lockfile). Required status check:
-  `js (lint, typecheck, build, test)`.
+- `js`: lint, typecheck, build, and test for the pnpm workspace (`apps/cli`, `apps/docs`, and
+  `examples`). Each task type has its own `pnpm turbo run` step so a stall names the exact
+  check. Every step runs across all three workspaces, including on workflow-only changes.
+  Required status check: `js (lint, typecheck, build, test)`.
 - `clean-install` — proves a fresh `git clone` with no `.env` and no repo secrets can install and
   typecheck the JS/TS workspace and `apps/api`, matching `CONTRIBUTING.md`'s own quickstart.
   `continue-on-error: true` — not a required check, it's a canary for "did we accidentally start
@@ -92,8 +91,8 @@ expected, not a bug.
   `enable-cache: true`. Wired up in `ci.yml` (`clean-install`, `api`, `alembic-check`) and
   `security.yml` (`api-audit`).
 - **No Turbo remote cache in this repo.** Fork PRs never receive secrets, and remote caching
-  needs a token, so this repo runs every turbo invocation cold. `--affected` still scopes work to
-  packages actually touched by a diff, which is most of the win.
+  needs a token, so this repo runs every turbo invocation cold. The `js` job checks all three
+  workspaces on purpose so changes to the workflow itself cannot pass with zero tasks.
 - No caching is wired up for `apps/store`'s `bun install` — `oven-sh/setup-bun` doesn't cache by
   default and none of the `store`/`api`/`extraction-eval` jobs opt into one.
 


### PR DESCRIPTION
## What & why

Closes #167.

Fork PRs touching the JavaScript workspaces were reaching the 20-minute limit inside one combined Turbo command. I split lint, typecheck, build, and test into named steps so the log identifies the stalled check. The first hosted run then passed lint, typecheck, and build before hanging in the CLI test suite.

The examples suite completed, but the CLI's single `bun test` process stopped producing output and stayed alive. Pinning Bun from 1.3.14 to 1.3.13 did not change the hosted behavior, so the current workflow keeps 1.3.14 and runs each of the 79 CLI test files in a fresh process. No tests are dropped, in-process test state cannot leak between files, and a future hang will name the exact file.

The job runs all three JavaScript workspaces on purpose. The old `--affected` command selected no tasks for a workflow-only change, which could let a CI fix pass without testing itself. I also updated `docs/ci/README.md` after review caught the old command still being documented.

## Test plan

- [x] Verified the official Bun 1.3.14 checksum before local execution
- [x] Ran all 79 CLI test files with the exact per-file loop: 79 passed
- [x] Ran the examples suite: 4 passed
- [x] Ran `pnpm turbo run lint`
- [x] Ran `pnpm turbo run typecheck`
- [x] Ran `pnpm turbo run build`
- [x] Ran `python3 .github/scripts/check_workflow_security.py`
- [x] Ran checksummed actionlint 1.7.12 against `ci.yml`
- [x] Passed the repository DCO checker for all three commits
- [x] Hosted Linux run on `07df477`: every required check passed, and the JavaScript job finished in 1m20s

## Before you open this

- [x] Every commit is signed off.
- [x] The CI guide matches the new workflow.
- [x] The change adds no runtime code or dependency.
- [x] The workflow keeps the repository's pinned-action and fork-runner rules.
- [x] This does not touch tenant data or extraction behavior.
