### PR TITLE
docs(cursor): add gnt integration guide

### DIFF
--- a/integrations/cursor/CONNECT.md
+++ b/integrations/cursor/CONNECT.md
@@ -1,0 +1,106 @@
+# Connecting Cursor to gnt-brain
+
+gnt-brain is gnt's rules-governance MCP server. Once Cursor is connected, it can use
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+The MCP entry only makes the tools available. Install the skill in this directory too, so
+Cursor knows when it must call `check_action` and how to handle each verdict.
+
+## Add the MCP server
+
+We verified this config shape on 2026-08-15 against Cursor's current
+[MCP documentation](https://cursor.com/docs/mcp). Cursor reads project servers from
+`.cursor/mcp.json` and global servers from `~/.cursor/mcp.json`. Remote servers use a `url`
+plus optional `headers`, and header values support `${env:NAME}` interpolation.
+
+Add this entry to the `mcpServers` object in the appropriate `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "gnt-brain": {
+      "url": "https://api.gntai.dev/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${env:GNT_MCP_KEY}"
+      }
+    }
+  }
+}
+```
+
+Keep the trailing slash in the URL. The deployed server redirects `/mcp` to `/mcp/`, so this
+points Cursor at the final endpoint instead of relying on redirect handling.
+
+Create a key with `gnt keys create`, or use an existing key from `gnt keys list`. Make it
+available to the process that starts Cursor:
+
+```bash
+export GNT_MCP_KEY="gnt_live_..."
+cursor .
+```
+
+PowerShell:
+
+```powershell
+$env:GNT_MCP_KEY = "gnt_live_..."
+cursor .
+```
+
+Restart Cursor from that environment if it was already running. Do not replace the environment
+reference with the real key in `mcp.json`, and do not commit or paste the key into logs.
+
+## Install the action-check skill
+
+We verified the skill layout on 2026-08-15 against Cursor's current
+[Agent Skills documentation](https://cursor.com/docs/skills). Cursor discovers a folder
+containing `SKILL.md` under `.cursor/skills/` or `.agents/skills/` for a project, and under
+the matching directories in the user's home directory for global use.
+
+From this integration directory, install the packaged skill for one project:
+
+```bash
+mkdir -p /path/to/project/.cursor/skills
+cp -R skill/gnt-check-action /path/to/project/.cursor/skills/gnt-check-action
+```
+
+For every Cursor project, copy it to the global skills directory instead:
+
+```bash
+mkdir -p ~/.cursor/skills
+cp -R skill/gnt-check-action ~/.cursor/skills/gnt-check-action
+```
+
+Cursor can select the skill when a request matches its description, or you can invoke
+`/gnt-check-action` in Agent chat. [`TOOLS.md`](TOOLS.md) contains the same policy in plain
+Markdown if you need to merge it into an existing `AGENTS.md` or an always-applied Cursor rule.
+
+The skill is guidance, not an enforcement boundary. Any client that performs side effects must
+still reject the action unless it receives an `allowed` verdict for the exact recipient, amount,
+target, and scope.
+
+## Verify the connection
+
+The installed Cursor Agent CLI exposes read-only checks for configured MCP servers:
+
+```bash
+cursor-agent mcp list
+cursor-agent mcp enable gnt-brain
+cursor-agent mcp list-tools gnt-brain
+```
+
+A newly discovered server starts in `needs approval`. Review the URL and headers first, then
+approve it in Cursor or with `cursor-agent mcp enable gnt-brain`. The final command should list
+all five tools named above.
+
+If `gnt-brain` does not become active, confirm that Cursor inherited `GNT_MCP_KEY`, inspect MCP
+Logs in Cursor's Output panel, and check that the URL retains its trailing slash.
+
+Then open Agent chat and run two behavior checks against non-production test rules:
+
+1. Ask Cursor to take an action covered by a blocking rule. It must call `check_action` and stop
+   when the verdict is `blocked`.
+2. Ask it to take an action with no approved rule. It must stop and ask for human approval when
+   the verdict is `needs_human`.
+
+Do not connect these checks to a real payment, messaging, or deletion tool. A successful MCP
+connection proves tool availability. The two prompts prove that the instruction layer uses the
+tool, while executor-side gating remains the final control.

--- a/integrations/cursor/CONNECT.md
+++ b/integrations/cursor/CONNECT.md
@@ -30,8 +30,10 @@ Add this entry to the `mcpServers` object in the appropriate `mcp.json`:
 Keep the trailing slash in the URL. The deployed server redirects `/mcp` to `/mcp/`, so this
 points Cursor at the final endpoint instead of relying on redirect handling.
 
-Create a key with `gnt keys create`, or use an existing key from `gnt keys list`. Make it
-available to the process that starts Cursor:
+`gnt keys create` prints a new key once. Use that value, or a plaintext key you already stored
+securely. `gnt keys list` shows IDs and status only; it cannot recover the secret. If the value is
+lost, create a new key or run `gnt keys rotate <id>`. Make the key available to the process that
+starts Cursor:
 
 ```bash
 export GNT_MCP_KEY="gnt_live_..."

--- a/integrations/cursor/TOOLS.md
+++ b/integrations/cursor/TOOLS.md
@@ -1,0 +1,31 @@
+# gnt-brain tools
+
+This project is connected to gnt-brain through Cursor's MCP configuration. gnt-brain exposes
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+This instruction does not enforce the decision by itself. The client or executor that performs
+the side effect must require an `allowed` verdict for the same recipient, amount, target, and
+scope. Run a new check if any of those details change.
+
+* If the verdict is `allowed`, proceed.
+* If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+* If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find the organization's approved rules. Use `get_rule` when you need the
+full text of one rule. Draft, in-review, rejected, and deprecated rules are not policy.
+
+Use `list_skill_packs` and `get_skill_pack` for compiled company context instead of guessing.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or choose a branch for the human.
+Show the proposed action and gnt-brain's reason, then wait for the decision.

--- a/integrations/cursor/skill/gnt-check-action/SKILL.md
+++ b/integrations/cursor/skill/gnt-check-action/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gnt-check-action
+description: Check a side-effectful action against this organization's approved gnt rules before taking it, and stop on a blocked or needs_human verdict.
+---
+
+# Check actions with gnt-brain
+
+Cursor has gnt-brain available as an MCP server named `gnt-brain`. It exposes `check_action`,
+`search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+The client or executor must require an `allowed` verdict for the same recipient, amount, target,
+and scope. Run a new check if any detail changes.
+
+* If the verdict is `allowed`, proceed.
+* If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+* If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find approved rules and `get_rule` to retrieve the full text of a rule.
+Use `list_skill_packs` and `get_skill_pack` for compiled company context. Do not infer policy
+from drafts, rules in review, rejected rules, or deprecated rules.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or decide for the human. Show
+the proposed action and gnt-brain's reason, then wait for the decision.


### PR DESCRIPTION
## What & why

Closes #78.

Cursor users did not have a checked-in way to connect to gnt-brain or tell the Agent when an action needs a policy check. I added a setup guide using Cursor's current MCP format, an installable `gnt-check-action` skill, and a plain `TOOLS.md` version for projects that already maintain their own instructions.

The MCP example reads `GNT_MCP_KEY` from the environment, keeps the token out of the repository, and points directly at the deployed trailing-slash endpoint. The guide also covers Cursor's approval step and commands for listing the five expected tools.

`gnt keys create` prints the secret once. The guide now says that plainly and does not send users to `gnt keys list`, which only shows IDs and status. If the secret is gone, users must create a new key or rotate the old one.

The skill does not enforce anything by itself. Cursor may proceed only after `check_action` returns `allowed` for the exact action details. A client that performs the side effect still has to enforce that verdict.

## Test plan

- [x] Parsed the documented `mcp.json` example with `jq`
- [x] Cursor Agent CLI `2026.06.26-7079533` loaded the sample and reported `gnt-brain` as awaiting approval
- [x] Confirmed `/mcp` redirects to `/mcp/` and the final endpoint rejects requests without a key
- [x] Checked every documentation link successfully
- [x] Validated the packaged skill with the official skill validator
- [x] Ran whitespace checks and gitleaks against the new integration
- [x] Ran `bun test test/keys.test.ts`: 10 passed
- [x] Hosted run on `f942367`: every required check passed

I did not approve the temporary Cursor server or read or create a real MCP key, so an authenticated tool listing and live verdict remain reviewer checks.

## Before you open this

- [x] Every commit is signed off and passes the repository DCO checker.
- [x] Cursor parsed the documented configuration with a fake key.
- [x] The integration adds documentation and an Agent skill, with no runtime code or dependency.
- [x] The skill fails closed when a verdict is missing, failed, expired, or unclear.
- [x] The guide keeps project files free of MCP credentials.
- [x] This does not touch tenant data or extraction behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cursor integration instructions for connecting to the MCP server and configuring authentication.
  * Documented installation and verification of the action-checking skill.
  * Added guidance for using MCP tools, approved rules, and skill packs.
  * Clarified safeguards for irreversible actions, including handling blocked, failed, expired, unclear, or human-review verdicts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->