### PR TITLE
docs(zed): add gnt integration guide

### DIFF
--- a/integrations/zed/CONNECT.md
+++ b/integrations/zed/CONNECT.md
@@ -32,8 +32,10 @@ top-level settings object:
 Keep the trailing slash in the URL. The deployed server redirects `/mcp` to `/mcp/`, so this
 points Zed at the final endpoint.
 
-Create a key with `gnt keys create`, or use an existing key from `gnt keys list`. Replace only
-the placeholder inside your user settings file.
+`gnt keys create` prints a new key once. Use that value, or a plaintext key you already stored
+securely. `gnt keys list` shows IDs and status only; it cannot recover the secret. If the value is
+lost, create a new key or run `gnt keys rotate <id>`. Replace only the placeholder inside your
+user settings file.
 
 Zed 1.15 does not interpolate environment variables in remote MCP headers. Its HTTP settings
 schema treats each header value as a literal string and passes that map to the transport. This

--- a/integrations/zed/CONNECT.md
+++ b/integrations/zed/CONNECT.md
@@ -1,0 +1,105 @@
+# Connecting Zed to gnt-brain
+
+gnt-brain is gnt's rules-governance MCP server. Once Zed is connected, its Agent can use
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+The connection makes those tools available, but it does not force the Agent to use them. Install
+the skill in this directory too, or merge `TOOLS.md` into the project's instructions.
+
+## Add the remote MCP server
+
+We verified this config shape on 2026-08-15 against Zed's current
+[MCP documentation](https://zed.dev/docs/ai/mcp) and the settings schema in
+[`settings_content`](https://github.com/zed-industries/zed/blob/main/crates/settings_content/src/project.rs).
+Zed stores custom MCP servers under `context_servers`; a remote server accepts `url`, `headers`,
+`enabled`, and an optional timeout.
+
+Open Zed's Command Palette, run `zed: open settings file`, and add this entry to the existing
+top-level settings object:
+
+```json
+{
+  "context_servers": {
+    "gnt-brain": {
+      "url": "https://api.gntai.dev/mcp/",
+      "headers": {
+        "Authorization": "Bearer <paste your gnt MCP key here>"
+      }
+    }
+  }
+}
+```
+
+Keep the trailing slash in the URL. The deployed server redirects `/mcp` to `/mcp/`, so this
+points Zed at the final endpoint.
+
+Create a key with `gnt keys create`, or use an existing key from `gnt keys list`. Replace only
+the placeholder inside your user settings file.
+
+Zed 1.15 does not interpolate environment variables in remote MCP headers. Its HTTP settings
+schema treats each header value as a literal string and passes that map to the transport. This
+means the native token setup stores the key in Zed's local settings file. Do not put this entry
+in a project's `.zed/settings.json`, commit it, paste it into logs, or share the file. If local
+plaintext token storage is outside your security policy, do not use this native setup until
+gnt-brain supports Zed's MCP OAuth flow or Zed adds secure header interpolation.
+
+## Install the action-check skill
+
+We verified the package layout on 2026-08-15 against Zed's current
+[Agent Skills documentation](https://zed.dev/docs/ai/skills). Zed loads global skills from
+`~/.agents/skills/` and project skills from `<worktree>/.agents/skills/`. Project skills load
+only after the worktree is trusted.
+
+From this integration directory, install the packaged skill for one project:
+
+```bash
+mkdir -p /path/to/project/.agents/skills
+cp -R skill/gnt-check-action /path/to/project/.agents/skills/gnt-check-action
+```
+
+For every Zed project, copy it to the global skills directory instead:
+
+```bash
+mkdir -p ~/.agents/skills
+cp -R skill/gnt-check-action ~/.agents/skills/gnt-check-action
+```
+
+Zed can select the skill when a request matches its description. You can also invoke it with
+`/gnt-check-action` or an `@` mention in the Agent Panel. [`TOOLS.md`](TOOLS.md) contains the
+same policy in plain Markdown. Merge it into the project's root `AGENTS.md` when the instruction
+must be present in every Agent chat. Preserve any instructions already in that file.
+
+The skill and instruction file are guidance, not an enforcement boundary. Any client that
+performs side effects must reject the action unless it receives an `allowed` verdict for the
+exact recipient, amount, target, and scope.
+
+## Prompt snippet
+
+If you do not install the packaged skill, add this snippet to the project's root `AGENTS.md` or
+paste it into the Agent Panel before asking Zed to act:
+
+```text
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call gnt-brain's check_action tool with the exact action. Proceed only when the verdict is
+allowed for the same recipient, amount, target, and scope. Stop on blocked. Stop and ask a human
+on needs_human. A missing, failed, expired, or unclear verdict is not permission to continue.
+```
+
+This prompt tells the Agent when to call the tool. The system that performs the side effect must
+still enforce the returned verdict.
+
+## Verify the connection
+
+Open Settings, select AI, then MCP Servers. The indicator next to `gnt-brain` should be green and
+its tooltip should say `Server is active`. If it is not active, check the URL, the Authorization
+header, and the MCP server status shown by Zed. Do not copy the header value into a bug report.
+
+Then run two behavior checks in the Agent Panel against non-production test rules:
+
+1. Ask Zed to take an action covered by a blocking rule. It must call `check_action` and stop
+   when the verdict is `blocked`.
+2. Ask it to take an action with no approved rule. It must stop and ask for human approval when
+   the verdict is `needs_human`.
+
+Do not connect these checks to a real payment, messaging, or deletion tool. A green server
+indicator proves the MCP connection. The prompts prove that the instruction layer uses the tool,
+while executor-side gating remains the final control.

--- a/integrations/zed/TOOLS.md
+++ b/integrations/zed/TOOLS.md
@@ -1,0 +1,31 @@
+# gnt-brain tools
+
+This project is connected to gnt-brain through Zed's MCP configuration. gnt-brain exposes
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+This instruction does not enforce the decision by itself. The client or executor that performs
+the side effect must require an `allowed` verdict for the same recipient, amount, target, and
+scope. Run a new check if any of those details change.
+
+* If the verdict is `allowed`, proceed.
+* If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+* If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find the organization's approved rules. Use `get_rule` when you need the
+full text of one rule. Draft, in-review, rejected, and deprecated rules are not policy.
+
+Use `list_skill_packs` and `get_skill_pack` for compiled company context instead of guessing.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or choose a branch for the human.
+Show the proposed action and gnt-brain's reason, then wait for the decision.

--- a/integrations/zed/skill/gnt-check-action/SKILL.md
+++ b/integrations/zed/skill/gnt-check-action/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gnt-check-action
+description: Check a side-effectful action against this organization's approved gnt rules before taking it, and stop on a blocked or needs_human verdict.
+---
+
+# Check actions with gnt-brain
+
+Zed has gnt-brain available as a context server named `gnt-brain`. It exposes `check_action`,
+`search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+The client or executor must require an `allowed` verdict for the same recipient, amount, target,
+and scope. Run a new check if any detail changes.
+
+* If the verdict is `allowed`, proceed.
+* If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+* If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find approved rules and `get_rule` to retrieve the full text of a rule.
+Use `list_skill_packs` and `get_skill_pack` for compiled company context. Do not infer policy
+from drafts, rules in review, rejected rules, or deprecated rules.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or decide for the human. Show
+the proposed action and gnt-brain's reason, then wait for the decision.


### PR DESCRIPTION
## What & why

Closes #82.

Zed users did not have a checked-in setup for gnt-brain or instructions for calling `check_action` before a side effect. I added a guide for Zed's current remote MCP format, an installable `gnt-check-action` skill, a plain `TOOLS.md` version, and the prompt snippet requested by the issue.

Zed 1.15 treats remote MCP header values as literal strings. The guide calls that out instead of suggesting environment interpolation that Zed does not support. It tells users to keep the token in user settings, never in a project's `.zed/settings.json`, and to wait for OAuth or secure interpolation if local plaintext storage violates their policy.

`gnt keys create` prints the secret once. The guide now says that plainly and does not send users to `gnt keys list`, which only shows IDs and status. If the secret is gone, users must create a new key or rotate the old one.

The skill requires an `allowed` verdict for the exact action details. Zed must stop on `blocked` or `needs_human`, while the client that performs the side effect remains responsible for enforcing the result.

## Test plan

- [x] Parsed the documented Zed settings example with `jq`
- [x] Checked the config against Zed 1.15 documentation and its current settings schema
- [x] Confirmed `/mcp` redirects to `/mcp/` and the final endpoint rejects requests without a key
- [x] Checked every documentation and source link successfully
- [x] Validated the packaged skill with the official skill validator
- [x] Ran whitespace checks and gitleaks against the new integration
- [x] Ran `bun test test/keys.test.ts`: 10 passed
- [x] Hosted run on `c528b47`: every required check passed

I did not place a real MCP key in Zed, so the green server indicator and live verdict checks remain reviewer steps.

## Before you open this

- [x] Every commit is signed off and passes the repository DCO checker.
- [x] The configuration matches Zed's current settings schema.
- [x] The integration adds documentation and an Agent skill, with no runtime code or dependency.
- [x] The skill fails closed when a verdict is missing, failed, expired, or unclear.
- [x] The guide states the plaintext-token limitation and keeps credentials out of project files.
- [x] This does not touch tenant data or extraction behavior.
