### PR TITLE
chore: add root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig - https://editorconfig.org
+# Canonical formatting for this repository. The committed tree uses LF line
+# endings (git ls-files --eol reports i/lf), 2-space indentation for
+# TypeScript/JavaScript/JSON/YAML/Markdown, and 4-space for Python (ruff's
+# default). Editors on any platform pick these up automatically, so no one
+# depends on local git or editor settings to produce a conforming file.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{json,jsonc,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{md,mdx}]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## What & why

Closes #146. The repo has no root .editorconfig, so editors fall back to their own defaults for indentation and line endings. The committed tree is LF (git ls-files --eol reports i/lf on every file I checked), but a Windows or mixed-environment checkout can silently produce CRLF or mixed-indent files. This pins the canonical formatting so any editor agrees on it:

- LF line endings, UTF-8, final newline, no trailing whitespace (repo-wide)
- 2-space indent for TS/JS/JSON/YAML/Markdown/shell
- 4-space indent for Python (ruff's default)

## Test plan

Validated with the editorconfig Python library against real files across the repo:

```
apps/cli/src/commands/rules-lint.ts  -> indent=2 eol=lf final_nl=true
apps/api/src/gnt/action_check.py    -> indent=4 eol=lf final_nl=true
setup.sh                            -> indent=2 eol=lf final_nl=true
apps/docs/pages/docs/mcp-clients.mdx -> indent=2 eol=lf final_nl=true
docker-compose.yml                  -> indent=2 eol=lf final_nl=true
package.json                        -> indent=2 eol=lf final_nl=true
```

No code paths touched; CI is unaffected (lint/typecheck/build/test suites don't read .editorconfig).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-wide formatting standards for line endings, indentation, final newlines, and trailing whitespace.
  * Defined consistent style rules across TypeScript, JavaScript, JSON, YAML, Markdown, shell, and Python files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->