### PR TITLE
feat(cli): add --json output to gnt rules lint

### DIFF
--- a/apps/cli/src/commands/rules-lint.ts
+++ b/apps/cli/src/commands/rules-lint.ts
@@ -16,6 +16,28 @@ interface LintIssue {
   message: string;
 }
 
+// One entry per file walked, in the same order the human-readable path
+// prints them. error is set only for file-level failures (an unreadable
+// file, a missing/malformed frontmatter fence); issues holds the per-field
+// frontmatter problems for files that parsed. A clean file is issues: []
+// with no error key at all.
+interface LintedFile {
+  path: string;
+  issues: LintIssue[];
+  error?: string;
+}
+
+// Shape of "gnt rules lint --json" -- the same numbers the human summary
+// line prints, plus per-file detail, so a CI step can consume real data
+// instead of scraping colored stdout (see .github/actions/lint-rules).
+interface LintReport {
+  files: LintedFile[];
+  checked: number;
+  clean: number;
+  with_issues: number;
+  ok: boolean;
+}
+
 interface ParsedRuleFile {
   frontmatter: Record<string, unknown>;
   body: string;
@@ -140,52 +162,78 @@ function resolveTargets(target: string): string[] {
 // apps/api's CreateRuleRequest and apps/store's RuleStatus enforce server-side
 // today -- so a malformed rule fails locally, before a PR round-trip, instead
 // of only surfacing once a maintainer opens the PR (see #97).
-export async function rulesLint(inputPath?: string): Promise<void> {
+//
+// Both output modes share the same walk and the same failure accounting; the
+// --json branch just renders the accumulated report instead of the colored
+// lines. Exit code is identical either way (1 when any file has issues), so
+// a CI step gets the same pass/fail signal from the machine-readable path.
+export async function rulesLint(inputPath?: string, options: { json?: boolean } = {}): Promise<void> {
   const target = resolve(inputPath ?? "rules");
   const files = resolveTargets(target);
 
   if (files.length === 0) {
+    if (options.json) {
+      console.log(JSON.stringify({ files: [], checked: 0, clean: 0, with_issues: 0, ok: true }, null, 2));
+      return;
+    }
     console.log(muted(`No rule files found at ${target}.`));
     return;
   }
 
-  let errorCount = 0;
-  let cleanCount = 0;
+  const report: LintReport = { files: [], checked: 0, clean: 0, with_issues: 0, ok: true };
 
   for (const filePath of files) {
     const relPath = relative(process.cwd(), filePath);
+    const linted: LintedFile = { path: relPath, issues: [] };
+
     let content: string;
     try {
       content = readFileSync(filePath, "utf-8");
     } catch (err) {
-      errorCount++;
-      console.log(fail(`${relPath}: could not read file (${(err as Error).message})`));
+      linted.error = `could not read file (${(err as Error).message})`;
+      report.with_issues++;
+      report.ok = false;
+      if (!options.json) console.log(fail(`${relPath}: ${linted.error}`));
+      report.files.push(linted);
       continue;
     }
 
     const parsed = parseRuleFile(content);
     if (!parsed) {
-      errorCount++;
-      console.log(fail(`${relPath}: missing or malformed frontmatter fence`));
+      linted.error = "missing or malformed frontmatter fence";
+      report.with_issues++;
+      report.ok = false;
+      if (!options.json) console.log(fail(`${relPath}: ${linted.error}`));
+      report.files.push(linted);
       continue;
     }
 
     const issues = lintFrontmatter(parsed.frontmatter, parsed.body);
+    linted.issues = issues;
     if (issues.length === 0) {
-      cleanCount++;
-      console.log(ok(relPath));
-      continue;
+      report.clean++;
+      if (!options.json) console.log(ok(relPath));
+    } else {
+      report.with_issues++;
+      report.ok = false;
+      if (!options.json) {
+        console.log(fail(relPath));
+        for (const issue of issues) {
+          console.log(`   ${dim(issue.field)} ${text(issue.message)}`);
+        }
+      }
     }
-
-    errorCount++;
-    console.log(fail(relPath));
-    for (const issue of issues) {
-      console.log(`   ${dim(issue.field)} ${text(issue.message)}`);
-    }
+    report.files.push(linted);
   }
 
-  console.log();
-  console.log(bold(`${cleanCount + errorCount} file(s) checked: ${cleanCount} clean, ${errorCount} with issues.`));
+  report.checked = report.files.length;
 
-  if (errorCount > 0) process.exit(1);
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log();
+    console.log(bold(`${report.checked} file(s) checked: ${report.clean} clean, ${report.with_issues} with issues.`));
+  }
+
+  if (report.with_issues > 0) process.exit(1);
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -406,7 +406,8 @@ const rules = program.command("rules").description("Work with local rule files")
 rules
   .command("lint [path]")
   .description("Validate rule frontmatter shape locally, before a PR round-trip (defaults to ./rules)")
-  .action(rulesLint);
+  .option("--json", "Print machine-readable JSON instead of the human-readable report")
+  .action((path: string | undefined, options: { json?: boolean }) => rulesLint(path, options));
 
 const keys = program.command("keys").description("Manage MCP keys used by agents");
 keys.command("list").description("List MCP keys").action(listKeys);

--- a/apps/cli/test/rules-lint.test.ts
+++ b/apps/cli/test/rules-lint.test.ts
@@ -172,3 +172,82 @@ test("lints a single file passed directly, not just a directory", async () => {
 
   expect(logs.join("\n")).toContain("1 clean, 0 with issues");
 });
+
+test("--json prints an empty report when no rule files exist", async () => {
+  await rulesLint(join(testDir, "nope"), { json: true });
+
+  expect(JSON.parse(logs.join("\n"))).toEqual({
+    files: [],
+    checked: 0,
+    clean: 0,
+    with_issues: 0,
+    ok: true,
+  });
+});
+
+test("--json reports a clean pass with per-file detail", async () => {
+  writeFileSync(join(testDir, "refund.md"), VALID_RULE);
+
+  await rulesLint(testDir, { json: true });
+
+  const report = JSON.parse(logs.join("\n"));
+  expect(report.ok).toBe(true);
+  expect(report.checked).toBe(1);
+  expect(report.clean).toBe(1);
+  expect(report.with_issues).toBe(0);
+  expect(report.files).toHaveLength(1);
+  expect(report.files[0].path).toContain("refund.md");
+  expect(report.files[0].issues).toEqual([]);
+  // A clean file carries no error key at all, not an empty string.
+  expect("error" in report.files[0]).toBe(false);
+});
+
+test("--json lists frontmatter issues per file and keeps the exit code", async () => {
+  const bad = `---
+title: ""
+status: bogus
+confidence: 1.5
+---
+
+Some body text.
+`;
+  writeFileSync(join(testDir, "bad.md"), bad);
+  const { exitCalls, restore } = stubExit();
+
+  try {
+    await expect(rulesLint(testDir, { json: true })).rejects.toThrow("process.exit called");
+  } finally {
+    restore();
+  }
+
+  expect(exitCalls).toEqual([1]);
+  const report = JSON.parse(logs.join("\n"));
+  expect(report.ok).toBe(false);
+  expect(report.checked).toBe(1);
+  expect(report.clean).toBe(0);
+  expect(report.with_issues).toBe(1);
+  expect(report.files[0].issues).toEqual(
+    expect.arrayContaining([
+      { field: "title", message: "must be a non-empty string" },
+      { field: "status", message: "must be one of draft, in_review, pending_merge, approved, deprecated (got \"bogus\")" },
+      { field: "confidence", message: "must be a number between 0 and 1 (got 1.5)" },
+    ]),
+  );
+});
+
+test("--json reports a malformed frontmatter fence as a file-level error", async () => {
+  writeFileSync(join(testDir, "broken.md"), "no frontmatter here\n");
+  const { exitCalls, restore } = stubExit();
+
+  try {
+    await expect(rulesLint(testDir, { json: true })).rejects.toThrow("process.exit called");
+  } finally {
+    restore();
+  }
+
+  expect(exitCalls).toEqual([1]);
+  const report = JSON.parse(logs.join("\n"));
+  expect(report.ok).toBe(false);
+  expect(report.files[0].error).toContain("missing or malformed frontmatter fence");
+  expect(report.files[0].issues).toEqual([]);
+});


### PR DESCRIPTION
## What & why

`gnt rules lint` only prints the colored human-readable report today, so the repo's own `.github/actions/lint-rules` and any external CI step have to scrape stdout if they want structured results. This adds a `--json` mode following the same pattern `status --json` / `gaps --json` already establish: the same walk, the same failure accounting, and the same exit code (1 when any file has issues) — just a machine-readable rendering of what the human path prints.

Closes #160.

## Test plan

Four new tests in `apps/cli/test/rules-lint.test.ts`:
- empty directory → empty report, exit 0
- clean pass → per-file detail with `issues: []` and no `error` key
- frontmatter issues → per-file issue list with `field`/`message`, exit stays 1
- malformed fence → file-level `error`, exit stays 1

`bun test test/rules-lint.test.ts` → 11 pass. `bun run typecheck`, `bun run lint`, and `bun run build` all pass.

Same rules dir, both modes (exit codes captured):

```
$ gnt rules lint rules
✗ rules/broken.md
   title must be a non-empty string
   status must be one of draft, in_review, pending_merge, approved, deprecated (got "bogus")
   confidence must be a number between 0 and 1 (got 1.5)
✗ rules/nofence.md: missing or malformed frontmatter fence
✓ rules/refund.md

3 file(s) checked: 1 clean, 2 with issues.
$ echo $?   # 1

$ gnt rules lint --json rules
{
  "files": [
    {
      "path": "rules/broken.md",
      "issues": [
        { "field": "title", "message": "must be a non-empty string" },
        { "field": "status", "message": "must be one of draft, in_review, pending_merge, approved, deprecated (got \"bogus\")" },
        { "field": "confidence", "message": "must be a number between 0 and 1 (got 1.5)" }
      ]
    },
    {
      "path": "rules/nofence.md",
      "issues": [],
      "error": "missing or malformed frontmatter fence"
    },
    {
      "path": "rules/refund.md",
      "issues": []
    }
  ],
  "checked": 3,
  "clean": 1,
  "with_issues": 2,
  "ok": false
}
$ echo $?   # 1
```

Clean run exits 0 with `"ok": true`, so the machine-readable path is a drop-in for the action's pass/fail signal — I left `.github/actions/lint-rules` on the human output for now since that's a separate change.

## Before you open this

- [x] Commits are signed off (`git commit -s`)
- [x] Functionally correct: ran the built CLI against real rule files, both modes and exit codes above
- [x] No dead code — `errorCount`/`cleanCount` folded into the report struct, all imports still used
- [x] Non-trivial logic has tests: 4 new ones covering every branch of the JSON path
- [x] No multi-tenant concerns — local file lint only
- [x] Follows the existing `status --json` / `gaps --json` pattern rather than inventing a new one
