### PR TITLE
feat(cli): add --json output to gnt org show

### DIFF
--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -19,7 +19,10 @@ async function errorMessage(res: Response, fallback: string): Promise<string> {
   return typeof body?.error === "string" ? body.error : `${fallback} (${res.status}).`;
 }
 
-export async function orgShow(): Promise<void> {
+// Same shape the human path reads, printed as-is in --json mode so a
+// script gets exactly what the server returned (id and any future fields
+// included), the way gaps --json passes its payload straight through.
+export async function orgShow(options: { json?: boolean } = {}): Promise<void> {
   const res = await orgFetch("");
   if (!res.ok) {
     console.error(fail(await errorMessage(res, "Failed to fetch organization")));
@@ -30,6 +33,11 @@ export async function orgShow(): Promise<void> {
     members: Array<{ email: string; role: string }>;
     invitations: Array<{ email: string; role: string }>;
   } = await res.json();
+
+  if (options.json) {
+    console.log(JSON.stringify(org, null, 2));
+    return;
+  }
 
   console.log(text(org.name));
   console.log();

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -431,7 +431,11 @@ webhook
 webhook.command("revoke <id>").description("Revoke a webhook token").action(revokeWebhookToken);
 
 const org = program.command("org").description("Manage your organization");
-org.command("show", { isDefault: true }).description("Show organization name, members, and pending invitations").action(orgShow);
+org
+  .command("show", { isDefault: true })
+  .description("Show organization name, members, and pending invitations")
+  .option("--json", "Print machine-readable JSON instead of the human-readable summary")
+  .action((options: { json?: boolean }) => orgShow(options));
 org.command("rename <name>").description("Rename the organization").action(orgRename);
 org
   .command("invite <email>")

--- a/apps/cli/test/org.test.ts
+++ b/apps/cli/test/org.test.ts
@@ -176,3 +176,45 @@ test("falls back to a status-coded message when the error body isn't JSON", asyn
   expect(exitCode).toBe(1);
   expect(errors.join("\n")).toContain("(401)");
 });
+
+test("orgShow --json passes the fetched org payload through as JSON", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          id: "org_1",
+          name: "Acme",
+          members: [{ email: "owner@acme.com", role: "owner" }],
+          invitations: [{ email: "pending@acme.com", role: "member" }],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch;
+
+  await orgShow({ json: true });
+
+  const report = JSON.parse(logs.join("\n"));
+  expect(report).toEqual({
+    id: "org_1",
+    name: "Acme",
+    members: [{ email: "owner@acme.com", role: "owner" }],
+    invitations: [{ email: "pending@acme.com", role: "member" }],
+  });
+});
+
+test("orgShow --json works with empty members and invitations", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ id: "org_1", name: "Acme", members: [], invitations: [] }), {
+        status: 200,
+      }),
+    ),
+  ) as unknown as typeof fetch;
+
+  await orgShow({ json: true });
+
+  const report = JSON.parse(logs.join("\n"));
+  expect(report.members).toEqual([]);
+  expect(report.invitations).toEqual([]);
+});


### PR DESCRIPTION
## What & why

`gnt org show` only has the human-readable summary, so scripting it (checking the org name or member roles in CI, an onboarding script that verifies an invite landed) means parsing the colored output. This adds a `--json` mode following the same pattern `status --json` / `gaps --json` establish: the same fetch and error handling, and the fetched org payload printed as-is — so a script gets exactly what the server returned (id included, plus any future fields), the way `gaps --json` passes its payload straight through.

Closes #159.

## Test plan

Two new tests in `apps/cli/test/org.test.ts`:
- payload with members + invitations round-trips through `--json` unchanged
- empty members/invitations still produce valid JSON

`bun test test/org.test.ts` → 9 pass. `tsc --noEmit`, `eslint .`, and `tsc` all pass.

`org show` needs the gnt backend to fetch from, so I can't paste a live transcript here (no org configured on this machine) — but the JSON branch is a straight pass-through of the response body, and the tests above pin the exact shape against a mocked response.

```
$ gnt org show --json
{
  "id": "org_1",
  "name": "Acme",
  "members": [{ "email": "owner@acme.com", "role": "owner" }],
  "invitations": [{ "email": "pending@acme.com", "role": "member" }]
}
```

## Before you open this

- [x] Commits are signed off (`git commit -s`)
- [x] Functionally correct: ran the built CLI (`org show --help` shows the new option; JSON branch covered by mocked-fetch tests since the live call needs gnt's backend)
- [x] No dead code — no unused imports, no debug output
- [x] Non-trivial logic has tests: 2 new ones pinning the JSON shape
- [x] Multi-tenant: the payload is the caller's own org via their own CLI key — no cross-org data touched
- [x] Follows the existing `status --json` / `gaps --json` pattern
