### PR TITLE
feat(cli): add --json output to gnt keys list

### DIFF
--- a/apps/cli/src/commands/keys.ts
+++ b/apps/cli/src/commands/keys.ts
@@ -18,7 +18,7 @@ async function authedFetch(key: string, path: string, init?: RequestInit): Promi
   });
 }
 
-export async function listKeys(): Promise<void> {
+export async function listKeys(options: { json?: boolean } = {}): Promise<void> {
   const key = loadApiKey();
   const res = await authedFetch(key, "/v1/settings/mcp-keys");
   if (!res.ok) {
@@ -26,6 +26,10 @@ export async function listKeys(): Promise<void> {
     process.exit(1);
   }
   const keys: McpKey[] = await res.json();
+  if (options.json) {
+    console.log(JSON.stringify(keys, null, 2));
+    return;
+  }
   if (keys.length === 0) {
     console.log(muted("No MCP keys yet. Create one with `gnt keys create`."));
     return;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -409,7 +409,11 @@ rules
   .action(rulesLint);
 
 const keys = program.command("keys").description("Manage MCP keys used by agents");
-keys.command("list").description("List MCP keys").action(listKeys);
+keys
+  .command("list")
+  .description("List MCP keys")
+  .option("--json", "Print machine-readable JSON instead of the human-readable list")
+  .action((options: { json?: boolean }) => listKeys(options));
 keys
   .command("create [name]")
   .description("Create a new MCP key")

--- a/apps/cli/test/keys.test.ts
+++ b/apps/cli/test/keys.test.ts
@@ -112,6 +112,40 @@ test("prints a message when there are no MCP keys", async () => {
   expect(output()).toContain("No MCP keys yet. Create one with `gnt keys create`.");
 });
 
+test("listKeys --json prints an empty array when there are no MCP keys", async () => {
+  mockFetch([]);
+
+  await listKeys({ json: true });
+
+  expect(JSON.parse(output())).toEqual([]);
+});
+
+test("listKeys --json prints the raw key list", async () => {
+  const payload = [
+    {
+      id: "a",
+      name: "short",
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: null,
+      revoked_at: null,
+      expires_at: null,
+    },
+    {
+      id: "revoked-id",
+      name: null,
+      created_at: "2026-08-01T00:00:00Z",
+      last_used_at: null,
+      revoked_at: "2026-08-02T09:00:00Z",
+      expires_at: null,
+    },
+  ];
+  mockFetch(payload);
+
+  await listKeys({ json: true });
+
+  expect(JSON.parse(output())).toEqual(payload);
+});
+
 test("lists aligned MCP keys with revoked, used, and unused states", async () => {
   mockFetch([
     {


### PR DESCRIPTION
## What & why

`gnt keys list` only prints the aligned human-readable table, so a script that needs the key ids or names (rotating all keys older than X, checking whether any are revoked) has to parse the padding-aligned stdout. This adds a `--json` mode following the same pattern `status --json` / `gaps --json` establish: the same fetch and error handling, and the key list printed as-is — including an empty `[]` for the no-keys case, so a consumer gets real data in every state (same as `gaps --json` with no gaps).

Closes #158.

## Test plan

Two new tests in `apps/cli/test/keys.test.ts`:
- no keys → `[]`
- a mixed list (named + revoked) round-trips through `--json` unchanged

`bun test test/keys.test.ts` → 12 pass. `tsc --noEmit`, `eslint .`, and `tsc` all pass.

`keys list` needs the gnt backend, so no live transcript here — the JSON branch is a straight pass-through of the response body and the tests pin the exact shape against a mocked response.

```
$ gnt keys list --json
[
  {
    "id": "a",
    "name": "short",
    "created_at": "2026-08-01T00:00:00Z",
    "last_used_at": null,
    "revoked_at": null,
    "expires_at": null
  }
]
```

## Before you open this

- [x] Commits are signed off (`git commit -s`)
- [x] Functionally correct: ran the built CLI (`keys list --help` shows the new option; JSON branch covered by mocked-fetch tests since the live call needs gnt's backend)
- [x] No dead code — no unused imports, no debug output
- [x] Non-trivial logic has tests: 2 new ones pinning the JSON shape
- [x] Multi-tenant: the payload is the caller's own MCP keys via their own CLI key — no cross-org data touched
- [x] Follows the existing `status --json` / `gaps --json` pattern
