### PR TITLE
test(cli): cover connect/disconnect figma

### DIFF
--- a/apps/cli/test/connect-figma.test.ts
+++ b/apps/cli/test/connect-figma.test.ts
@@ -1,0 +1,100 @@
+// Tests the non-TTY parts of `gnt connect figma` / `gnt disconnect figma`.
+// The masked keypress reader needs a real terminal, so -- same as
+// connect-datadog.test.ts -- this file covers resolve -> validate -> save and
+// the disconnect path directly instead of driving keypresses.
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { disconnectFigma } from "../src/commands/connect-figma.js";
+import { loadMcpToken, saveMcpToken } from "../src/credentials.js";
+import {
+  FIGMA_API_BASE,
+  FIGMA_TOKEN_ID,
+  FigmaApiError,
+  MissingFigmaTokenError,
+  resolveFigmaToken,
+  validateFigmaToken,
+} from "../src/prebrain/figma-comments.js";
+
+let testConfigDir: string;
+let logs: string[];
+let originalLog: typeof console.log;
+let originalTokenEnv: string | undefined;
+
+beforeEach(() => {
+  testConfigDir = mkdtempSync(join(tmpdir(), "gnt-connect-figma-test-"));
+  process.env.GNT_CONFIG_DIR = testConfigDir;
+  originalTokenEnv = process.env.GNT_FIGMA_TOKEN;
+  delete process.env.GNT_FIGMA_TOKEN;
+  logs = [];
+  originalLog = console.log;
+  console.log = mock((...args: unknown[]) => {
+    logs.push(args.join(" "));
+  });
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  rmSync(testConfigDir, { recursive: true, force: true });
+  delete process.env.GNT_CONFIG_DIR;
+  if (originalTokenEnv === undefined) delete process.env.GNT_FIGMA_TOKEN;
+  else process.env.GNT_FIGMA_TOKEN = originalTokenEnv;
+});
+
+test("successful save after validation passes", async () => {
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    expect(url).toContain(`${FIGMA_API_BASE}/v1/me`);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers["X-Figma-Token"]).toBe("figd-test-token");
+    return new Response(JSON.stringify({ id: "123", handle: "test-user" }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const token = resolveFigmaToken("figd-test-token", undefined);
+  expect(token).toBe("figd-test-token");
+
+  await validateFigmaToken(token, fetchImpl);
+  saveMcpToken(FIGMA_TOKEN_ID, token);
+
+  const stored = loadMcpToken(FIGMA_TOKEN_ID);
+  expect(stored).toBe("figd-test-token");
+});
+
+test("token resolves from GNT_FIGMA_TOKEN when not passed directly", () => {
+  process.env.GNT_FIGMA_TOKEN = "figd-env-token";
+  const token = resolveFigmaToken(undefined, undefined);
+  expect(token).toBe("figd-env-token");
+});
+
+test("stored token is used when neither explicit nor env is provided", () => {
+  const token = resolveFigmaToken(undefined, "figd-stored-token");
+  expect(token).toBe("figd-stored-token");
+});
+
+test("resolve throws when no token is available anywhere", () => {
+  expect(() => resolveFigmaToken(undefined, undefined)).toThrow(MissingFigmaTokenError);
+});
+
+test("validation failure leaves nothing saved", async () => {
+  const fetchImpl = (async () =>
+    new Response(JSON.stringify({ err: "Invalid token" }), { status: 403 })) as unknown as typeof fetch;
+
+  await expect(validateFigmaToken("bad-token", fetchImpl)).rejects.toBeInstanceOf(FigmaApiError);
+  expect(loadMcpToken(FIGMA_TOKEN_ID)).toBeUndefined();
+});
+
+test("disconnectFigma removes a saved connection and reports it removed", async () => {
+  saveMcpToken(FIGMA_TOKEN_ID, "figd-test-token");
+
+  await disconnectFigma();
+
+  expect(loadMcpToken(FIGMA_TOKEN_ID)).toBeUndefined();
+  expect(logs.join("\n")).toContain("Disconnected Figma");
+});
+
+test("disconnectFigma is a no-op when nothing was connected", async () => {
+  await disconnectFigma();
+
+  expect(logs.join("\n")).toContain("No stored Figma connection to remove.");
+});


### PR DESCRIPTION
## What & why

Closes #155. `apps/cli/src/commands/connect-figma.ts` had zero test coverage. The masked keypress reader needs a real terminal, so `connectFigma` itself can't be driven headless — same constraint `connect-datadog.test.ts` already documents. This file covers the non-TTY path the same way:

- resolve → validate → save, asserting the `X-Figma-Token` header on the `/v1/me` probe
- token resolution from `GNT_FIGMA_TOKEN` and from an already-stored token
- the missing-token error (`MissingFigmaTokenError`)
- validation failure leaving nothing saved
- both disconnect outcomes (removed vs. no-op)

## Test plan

```
bun test test/connect-figma.test.ts
 7 pass
 0 fail
 12 expect() calls
```

Plus `npx eslint test/connect-figma.test.ts` clean. (The full local suite has 7 pre-existing Windows-only failures — the zip CLI and 0600-chmod tests — which don't touch this file; CI on Linux runs them green.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for connecting to the service, including token validation and credential persistence.
  * Added tests for failed validation, disconnect behavior, and safely handling missing connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->