### PR TITLE
Add native Codex enforcement plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "gnt",
+  "interface": {
+    "displayName": "gnt"
+  },
+  "plugins": [
+    {
+      "name": "gnt",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/gnt-ai/gnt.git",
+        "path": "integrations/codex-plugin",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/integrations/codex-plugin/.codex-plugin/plugin.json
+++ b/integrations/codex-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "gnt",
+  "version": "0.6.4-codex.1",
+  "description": "Check consequential agent actions against approved company policy before execution.",
+  "author": {
+    "name": "gnt.ai",
+    "url": "https://gntai.dev"
+  },
+  "homepage": "https://gntai.dev",
+  "repository": "https://github.com/gnt-ai/gnt",
+  "license": "Apache-2.0",
+  "interface": {
+    "displayName": "gnt",
+    "shortDescription": "The check before the action",
+    "longDescription": "Fail-closed policy checks before consequential agent actions.",
+    "developerName": "gnt.ai",
+    "category": "Developer Tools",
+    "capabilities": ["Pre-tool enforcement"],
+    "websiteURL": "https://gntai.dev",
+    "defaultPrompt": [
+      "Check this action against our approved company policy."
+    ],
+    "brandColor": "#1D1D1B"
+  }
+}

--- a/integrations/codex-plugin/hooks/hooks.json
+++ b/integrations/codex-plugin/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "description": "Fail-closed gnt policy check before consequential Codex tools.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gnt hooks check-action",
+            "timeout": 20,
+            "statusMessage": "Checking company policy..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds the gnt Codex marketplace manifest and the fail-closed `PreToolUse` hook bundle. The hook uses a catch-all matcher so Codex can pass each tool event to the CLI, where safe read-only and gnt-internal tools are excluded before any network request.

Validated the manifests with `jq`, scanned both new paths with gitleaks, and proved the deny path against Codex 0.146.1 before publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the GNT plugin to the marketplace for easier discovery and installation.
  - Added Codex integration with policy checks that run automatically before tool actions.
  - Included plugin metadata, branding, and default policy guidance for a consistent setup.
  - Added clear status feedback while policy checks are running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->