### PR TITLE
docs(cline): add gnt integration guide

### DIFF
--- a/integrations/cline/CONNECT.md
+++ b/integrations/cline/CONNECT.md
@@ -1,0 +1,140 @@
+# Connecting Cline to gnt-brain
+
+gnt-brain is gnt's rules-governance MCP server. Once Cline is connected, it can use
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+The MCP connection makes those tools available; copy [`TOOLS.md`](TOOLS.md) into the
+project's Cline rules so the agent knows when to use them. For the shared endpoint and key
+background, see gnt's [generic MCP client guide](../../apps/docs/pages/docs/mcp-clients.mdx).
+
+## Add the remote MCP server
+
+This configuration follows Cline's current [MCP documentation](https://docs.cline.bot/mcp/mcp-overview)
+(checked 2026-08-19). Cline's VS Code extension can edit the configuration from the MCP Servers
+panel, while the current Cline CLI stores it in `~/.cline/mcp.json` on macOS and Linux. In the
+extension, open the MCP Servers icon, choose **Configure**, then **Configure MCP Servers**.
+
+The issue may refer to the older `cline_mcp_settings.json` filename. If an older Cline build still
+opens that file, use the file opened by its **Configure MCP Servers** button; the server entry
+itself has the same shape.
+
+Add this entry to the existing `mcpServers` object:
+
+```json
+{
+  "mcpServers": {
+    "gnt-brain": {
+      "type": "streamableHttp",
+      "url": "https://api.gntai.dev/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${env:GNT_MCP_KEY}"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+Keep the trailing slash in the URL. The deployed server redirects `/mcp` to `/mcp/`, so this
+points Cline at the final MCP endpoint instead of relying on redirect handling.
+
+`${env:GNT_MCP_KEY}` is expanded by Cline before it opens the connection. The syntax is handled
+recursively by Cline's [environment expansion code][cline-env-expansion].
+If you use the Cline CLI wizard and it writes a nested `transport` object, keep that structure and
+put `type`, `url`, and `headers` inside `transport`; the same values apply.
+
+Create a key with `gnt keys create`, or use an existing key that you stored securely. `gnt keys
+list` shows IDs and status only; it cannot recover the secret. If the value is lost, create a new
+key or run `gnt keys rotate <id>`. Make the key available to the process that starts Cline:
+
+```bash
+export GNT_MCP_KEY="gnt_live_..."
+cline
+```
+
+PowerShell:
+
+```powershell
+$env:GNT_MCP_KEY = "gnt_live_..."
+cline
+```
+
+Command Prompt (`cmd.exe`):
+
+```bat
+set "GNT_MCP_KEY=gnt_live_..."
+cline
+```
+
+Restart Cline after changing the environment. Do not replace the environment reference with the
+real key in `mcp.json`, and do not commit or paste the key into logs, issues, or support output.
+Keep `autoApprove` empty until you have reviewed what each server tool does.
+
+## Load the action policy
+
+Cline automatically loads Markdown and text files from a project's `.clinerules/` directory.
+See the [Cline rules documentation](https://docs.cline.bot/customization/cline-rules) for the
+workspace and global rule locations. Copy this integration's policy file into the project where
+Cline will work:
+
+```bash
+mkdir -p /path/to/project/.clinerules
+cp integrations/cline/TOOLS.md /path/to/project/.clinerules/gnt-check-action.md
+```
+
+The same policy can be installed globally in Cline's rules directory, but a project rule is easier
+to review and keeps the guardrail close to the code it protects. If the project already has a
+`.clinerules/` directory, add the file without replacing the existing rules.
+
+For an on-demand version, Cline also supports [Agent Skills](https://docs.cline.bot/customization/skills).
+The packaged skill in `skill/gnt-check-action/` can be copied to the recommended `.cline/skills/`
+directory (or the compatible `.clinerules/skills/` directory) in the project:
+
+```bash
+mkdir -p /path/to/project/.cline/skills
+cp -R integrations/cline/skill/gnt-check-action /path/to/project/.cline/skills/gnt-check-action
+```
+
+The skill is useful context, but `TOOLS.md` is the better choice when the check must be present in
+every Cline turn.
+
+Neither an MCP connection nor an instruction file is an enforcement boundary. The client or
+executor that performs a side effect must still reject the action unless it receives an `allowed`
+verdict for the exact recipient, amount, target, and scope.
+
+## Verify the connection
+
+After editing the configuration, use the Cline CLI to inspect it:
+
+```bash
+cline config mcp --json
+cline mcp
+```
+
+In the VS Code extension, open the MCP Servers panel and confirm that `gnt-brain` is active and
+that its five tools are listed. If it does not connect, check that Cline inherited `GNT_MCP_KEY`,
+that the URL still ends in `/mcp/`, and that the JSON is part of the existing `mcpServers` object.
+Do not include the Authorization header in a bug report.
+
+Then run two behavior checks against non-production test rules:
+
+1. Ask Cline to take an action covered by a blocking rule. It must call `check_action` and stop
+   when the verdict is `blocked`.
+2. Ask Cline to take an action with no approved rule. It must stop and ask a human for approval
+   when the verdict is `needs_human`.
+
+Do not connect these checks to a real payment, messaging, or deletion tool. A green MCP status
+proves that the tools are reachable. The two prompts check that the instruction layer uses the
+tools, while executor-side gating remains the final control.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Cline reports an authentication error | Confirm `GNT_MCP_KEY` is present in the environment inherited by Cline, then restart Cline. |
+| The server appears but has no tools | Confirm the entry uses `type: "streamableHttp"` and the URL includes the trailing slash. |
+| `${env:GNT_MCP_KEY}` is shown literally | Cline was not started with that environment variable, or the value is in the wrong config field. |
+| The policy is ignored | Confirm the file is under the workspace's `.clinerules/` directory and has a `.md` or `.txt` extension. |
+| `check_action` returns `needs_human` | Stop and ask the human; do not retry with a softer description or route around the check. |
+
+[cline-env-expansion]: https://github.com/cline/cline/blob/main/apps/vscode/src/utils/envExpansion.ts

--- a/integrations/cline/TOOLS.md
+++ b/integrations/cline/TOOLS.md
@@ -1,0 +1,34 @@
+# gnt-brain tools for Cline
+
+This file is intended to be copied into a project's `.clinerules/` directory. The MCP connection
+is configured separately; see [`CONNECT.md`](CONNECT.md).
+
+gnt-brain exposes `check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and
+`get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+This instruction does not enforce the decision by itself. The client or executor that performs
+the side effect must require an `allowed` verdict for the same recipient, amount, target, and
+scope. Run a new check if any of those details change.
+
+- If the verdict is `allowed`, proceed with the action.
+- If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+- If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find the organization's approved rules. Use `get_rule` when you need the
+full text of one rule. Draft, in-review, rejected, and deprecated rules are not policy.
+
+Use `list_skill_packs` and `get_skill_pack` for compiled company context instead of guessing.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or choose a branch for the human.
+Show the proposed action and gnt-brain's reason, then wait for the decision.

--- a/integrations/cline/skill/gnt-check-action/SKILL.md
+++ b/integrations/cline/skill/gnt-check-action/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gnt-check-action
+description: Check a side-effectful action against this organization's approved gnt rules before taking it, and stop on a blocked or needs_human verdict.
+---
+
+# Check actions with gnt-brain
+
+Cline has gnt-brain available as an MCP server named `gnt-brain`. It exposes `check_action`,
+`search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+The client or executor must require an `allowed` verdict for the same recipient, amount, target,
+and scope. Run a new check if any detail changes.
+
+- If the verdict is `allowed`, proceed.
+- If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+- If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find approved rules and `get_rule` to retrieve the full text of a rule. Use
+`list_skill_packs` and `get_skill_pack` for compiled company context. Do not infer policy from
+drafts, rules in review, rejected rules, or deprecated rules.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or decide for the human. Show the
+proposed action and gnt-brain's reason, then wait for the human's decision.


### PR DESCRIPTION
## What & why

Closes #147.

Cline has first-class MCP support, but gnt did not have a Cline-specific integration guide. This adds:

- the current remote Streamable HTTP configuration for the VS Code extension and Cline CLI;
- environment-variable handling for the MCP key, including the older `cline_mcp_settings.json` filename;
- workspace `.clinerules/` and optional `.cline/skills/` installation instructions;
- connection checks, safe behavior checks, and troubleshooting guidance;
- the `check_action` policy adapted for Cline's persistent rules.

The guide keeps `autoApprove` empty and makes clear that model instructions do not replace enforcement in the executor.

## Test plan

- [x] Verified the remote configuration shape against [Cline's MCP documentation](https://docs.cline.bot/mcp/mcp-overview) on 2026-08-19.
- [x] Verified Cline's `${env:NAME}` expansion against its [environment expansion implementation](https://github.com/cline/cline/blob/main/apps/vscode/src/utils/envExpansion.ts).
- [x] Verified the `.clinerules/` and `.cline/skills/` locations against Cline's [rules](https://docs.cline.bot/customization/cline-rules) and [skills](https://docs.cline.bot/customization/skills) documentation.
- [x] Parsed the JSON configuration example with Python's standard library and asserted the transport, endpoint, header interpolation, and empty `autoApprove` values.
- [x] Checked all Markdown files for trailing newlines/tabs and ran `git diff --check`.
- [ ] Hosted CI (after opening the PR).
- [ ] Manual Cline connection test, since it requires a live MCP key and a local Cline installation.

The repository's docs lint could not reach ESLint locally because dependency installation stopped with `No space left on device` after the machine reached 100% disk usage. No application dependencies or source files were changed.

## Before you open this

- [x] Commits are signed off (`git commit -s`).
- [x] Functionally correct: the configuration example and documented paths were checked against current Cline documentation.
- [x] No dead code — documentation-only change.
- [x] Non-trivial logic — no application logic added.
- [x] Matches the repository's existing integration patterns.
