### PR TITLE
docs: keep store env example in sync

### DIFF
--- a/apps/store/.env.example
+++ b/apps/store/.env.example
@@ -15,7 +15,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/gnt_store
 # Where the engine clones org rules repos to disk. Defaults to a tmpdir
 # if unset — set this explicitly in production to a persistent volume
 # path if repo clones should survive a restart instead of re-cloning.
-GNT_STORE_CLONES_DIR=/data/gnt-store-clones
+# GNT_STORE_CLONES_DIR=/data/gnt-store-clones
 
 # Set to 1 only when deliberately exposing the store through a public domain.
 # GNT_STORE_ALLOW_PUBLIC_DOMAIN=1

--- a/apps/store/.env.example
+++ b/apps/store/.env.example
@@ -4,6 +4,9 @@ GNT_STORE_PORT=8787
 GNT_STORE_BIND=127.0.0.1
 GNT_STORE_INTERNAL_API_SECRET=change-me-to-a-random-secret
 
+# Storage backend. Native is currently the only supported value.
+STORE_BACKEND=native
+
 # Required — NativeStore is Postgres-only, no in-memory mode. Plain
 # postgres:// connection string (not the postgresql+asyncpg:// form
 # apps/api uses).
@@ -12,7 +15,10 @@ DATABASE_URL=postgres://user:password@localhost:5432/gnt_store
 # Where the engine clones org rules repos to disk. Defaults to a tmpdir
 # if unset — set this explicitly in production to a persistent volume
 # path if repo clones should survive a restart instead of re-cloning.
-# GNT_STORE_CLONES_DIR=/data/gnt-store-clones
+GNT_STORE_CLONES_DIR=/data/gnt-store-clones
+
+# Set to 1 only when deliberately exposing the store through a public domain.
+# GNT_STORE_ALLOW_PUBLIC_DOMAIN=1
 
 # Authorizes specifically an approved-status write (see
 # src/core/approval-signing.ts) — a different secret from

--- a/docs/self-hosting/env-vars.md
+++ b/docs/self-hosting/env-vars.md
@@ -158,7 +158,8 @@ closed (every call between the two services rejected), not open.
 
 Hand-enumerated from the actual `process.env.X` reads in
 `apps/store/src/http/server.ts`, `apps/store/src/native/embed.ts`, and
-`apps/store/src/native/rerank.ts` — not from `.env.example`.
+`apps/store/src/native/rerank.ts`; the example file mirrors the deployable
+variables below.
 
 | Env var | Required | Default | Notes |
 |---|---|---|---|

--- a/docs/self-hosting/env-vars.md
+++ b/docs/self-hosting/env-vars.md
@@ -158,8 +158,7 @@ closed (every call between the two services rejected), not open.
 
 Hand-enumerated from the actual `process.env.X` reads in
 `apps/store/src/http/server.ts`, `apps/store/src/native/embed.ts`, and
-`apps/store/src/native/rerank.ts`; the example file mirrors the deployable
-variables below.
+`apps/store/src/native/rerank.ts` — not from `.env.example`.
 
 | Env var | Required | Default | Notes |
 |---|---|---|---|


### PR DESCRIPTION
## Summary\n\nKeep pps/store/.env.example aligned with the documented runtime variables.\n\n## Changes\n\n- Add STORE_BACKEND and the public-domain guard to the example.\n- Provide the persistent clone-directory setting as a deployable example.\n- Remove the documentation note that the example omits runtime variables.\n\nCloses #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the supported native storage backend configuration.
  * Added an example setting for optionally exposing the store through a public domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->