### PR TITLE
chore: add pre-commit lint hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint (TypeScript apps)
+        entry: pnpm exec eslint
+        language: system
+        files: ^apps/(cli|store)/.*\.(c|m)?[jt]sx?$
+        types: [file]
+      - id: ruff
+        name: ruff (API)
+        entry: uv run --project apps/api ruff check
+        language: system
+        files: ^apps/api/.*\.py$
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,20 @@
 repos:
   - repo: local
     hooks:
-      - id: eslint
-        name: eslint (TypeScript apps)
-        entry: pnpm exec eslint
+      - id: eslint-cli
+        name: eslint (CLI)
+        entry: pnpm --filter @gnt-ai/cli lint
         language: system
-        files: ^apps/(cli|store)/.*\.(c|m)?[jt]sx?$
+        files: ^apps/cli/.*\.(c|m)?[jt]sx?$
         types: [file]
+        pass_filenames: false
+      - id: eslint-store
+        name: eslint (store)
+        entry: bash -c 'cd apps/store && bun run lint'
+        language: system
+        files: ^apps/store/.*\.(c|m)?[jt]sx?$
+        types: [file]
+        pass_filenames: false
       - id: ruff
         name: ruff (API)
         entry: uv run --project apps/api ruff check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,17 @@ CI enforces this on every PR (and on pushes to `main`): the `dco` job in
 any non-merge commit in the range is missing an author-matching `Signed-off-by` trailer. Fix a
 tip commit with `git commit --amend -s`, or older commits with `git rebase --signoff <base>`.
 
+## Run local checks before committing
+
+Install the repository hooks once after installing [pre-commit](https://pre-commit.com/):
+
+```bash
+pre-commit install
+```
+
+The hooks run the relevant CLI, store, or API linter for files in your commit. You can also run
+them manually with `pre-commit run --all-files`.
+
 ## Opening a PR
 
 Use the PR template. If you're adding a new connector, see the "connector request" issue


### PR DESCRIPTION
## Summary
- add dependency-free local pre-commit hooks for the TypeScript apps and API
- run ESLint only for staged apps/cli and apps/store files
- run Ruff only for staged apps/api Python files

Closes #212

## Validation
- git diff --check
- ESLint could not run because the workspace root has no installed ESLint binary
- Ruff could not complete because uv was still bootstrapping Python in this environment