### PR TITLE
docs(opencode): add gnt integration guide

### DIFF
--- a/integrations/opencode/CONNECT.md
+++ b/integrations/opencode/CONNECT.md
@@ -37,8 +37,8 @@ points OpenCode at the final MCP endpoint instead of relying on redirect handlin
 prevents OpenCode from starting its automatic OAuth flow for this API-key-authenticated server.
 
 Create a key with `gnt keys create`, or use an existing key that you stored securely. `gnt keys
-list` shows IDs and status only; it cannot recover the secret. If the value is lost, create a new
-key or run `gnt keys rotate <id>`. Make the key available to the process that starts OpenCode:
+list` shows key metadata and status, but it cannot recover the secret. If the value is lost, create
+a new key or run `gnt keys rotate <id>`. Make the key available to the process that starts OpenCode:
 
 ```bash
 export GNT_MCP_KEY="gnt_live_..."
@@ -100,9 +100,9 @@ Restart OpenCode, then list the configured MCP servers:
 opencode mcp list
 ```
 
-Confirm that `gnt-brain` is connected. If it is not, run `opencode mcp debug gnt-brain`, check that
-OpenCode inherited `GNT_MCP_KEY`, and confirm that the URL ends in `/mcp/`. Do not include the
-Authorization header in a bug report.
+Confirm that `gnt-brain` is connected. If it is not, first check that OpenCode inherited
+`GNT_MCP_KEY` and that the URL ends in `/mcp/`. For OAuth-oriented connection diagnostics, run
+`opencode mcp debug gnt-brain`. Do not include the Authorization header in a bug report.
 
 Then run two behavior checks against non-production test rules:
 

--- a/integrations/opencode/CONNECT.md
+++ b/integrations/opencode/CONNECT.md
@@ -1,0 +1,126 @@
+# Connecting OpenCode to gnt-brain
+
+gnt-brain is gnt's rules-governance MCP server. Once OpenCode is connected, it can use
+`check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and `get_skill_pack`.
+The MCP connection makes those tools available; load [`TOOLS.md`](TOOLS.md) as an OpenCode
+instruction too so the agent knows when to use them. For the shared endpoint and key background,
+see gnt's [generic MCP client guide](../../apps/docs/pages/docs/mcp-clients.mdx).
+
+## Add the remote MCP server
+
+This configuration follows OpenCode's current [MCP server documentation](https://opencode.ai/docs/mcp-servers)
+(checked 2026-08-29). OpenCode merges global configuration from
+`~/.config/opencode/opencode.json` with a project's `opencode.json`, so add the server to whichever
+scope should have access to gnt-brain.
+
+Add this entry to the existing top-level `mcp` object:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "gnt-brain": {
+      "type": "remote",
+      "url": "https://api.gntai.dev/mcp/",
+      "enabled": true,
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {env:GNT_MCP_KEY}"
+      }
+    }
+  }
+}
+```
+
+Keep the trailing slash in the URL. The deployed server redirects `/mcp` to `/mcp/`, so this
+points OpenCode at the final MCP endpoint instead of relying on redirect handling. `oauth: false`
+prevents OpenCode from starting its automatic OAuth flow for this API-key-authenticated server.
+
+Create a key with `gnt keys create`, or use an existing key that you stored securely. `gnt keys
+list` shows IDs and status only; it cannot recover the secret. If the value is lost, create a new
+key or run `gnt keys rotate <id>`. Make the key available to the process that starts OpenCode:
+
+```bash
+export GNT_MCP_KEY="gnt_live_..."
+opencode
+```
+
+PowerShell:
+
+```powershell
+$env:GNT_MCP_KEY = "gnt_live_..."
+opencode
+```
+
+Command Prompt (`cmd.exe`):
+
+```bat
+set "GNT_MCP_KEY=gnt_live_..."
+opencode
+```
+
+OpenCode expands `{env:GNT_MCP_KEY}` while loading the configuration. Restart OpenCode after
+changing the environment or configuration. Do not replace the environment reference with the real
+key in a project config, and do not commit or paste the key into logs, issues, or support output.
+
+## Load the action policy
+
+OpenCode can load reusable instruction files through the top-level `instructions` array, as
+described in its [rules documentation](https://opencode.ai/docs/rules). Copy this integration's
+policy file into the project where OpenCode will work:
+
+```bash
+mkdir -p /path/to/project/.opencode
+cp integrations/opencode/TOOLS.md /path/to/project/.opencode/gnt-brain.md
+```
+
+Then add that file to the project's existing `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [".opencode/gnt-brain.md"]
+}
+```
+
+Merge this field with the MCP configuration above and preserve any existing instruction paths.
+As an alternative, merge the contents of `TOOLS.md` into the project's root `AGENTS.md`; OpenCode
+loads that file automatically. A project-local instruction is easier to review and keeps the
+guardrail close to the tools it protects.
+
+Neither an MCP connection nor an instruction file is an enforcement boundary. The client or
+executor that performs a side effect must still reject the action unless it receives an `allowed`
+verdict for the exact recipient, amount, target, and scope.
+
+## Verify the connection
+
+Restart OpenCode, then list the configured MCP servers:
+
+```bash
+opencode mcp list
+```
+
+Confirm that `gnt-brain` is connected. If it is not, run `opencode mcp debug gnt-brain`, check that
+OpenCode inherited `GNT_MCP_KEY`, and confirm that the URL ends in `/mcp/`. Do not include the
+Authorization header in a bug report.
+
+Then run two behavior checks against non-production test rules:
+
+1. Ask OpenCode to take an action covered by a blocking rule. It must call `check_action` and stop
+   when the verdict is `blocked`.
+2. Ask OpenCode to take an action with no approved rule. It must stop and ask a human for approval
+   when the verdict is `needs_human`.
+
+Do not connect these checks to a real payment, messaging, or deletion tool. A connected MCP status
+proves that the tools are reachable. The two prompts check that the instruction layer uses the
+tools, while executor-side gating remains the final control.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| OpenCode reports an authentication error | Confirm `GNT_MCP_KEY` is present in the environment inherited by OpenCode, then restart it. |
+| The server appears but does not connect | Confirm the entry uses `type: "remote"`, `oauth: false`, and a URL ending in `/mcp/`. |
+| `{env:GNT_MCP_KEY}` is sent literally | Confirm the value is in `headers`, the environment variable is set, and OpenCode is current. |
+| The policy is ignored | Confirm `.opencode/gnt-brain.md` is listed in the project's `instructions` array, or merge it into `AGENTS.md`. |
+| `check_action` returns `needs_human` | Stop and ask the human; do not retry with a softer description or route around the check. |

--- a/integrations/opencode/TOOLS.md
+++ b/integrations/opencode/TOOLS.md
@@ -1,0 +1,35 @@
+# gnt-brain tools for OpenCode
+
+This file is intended to be loaded through OpenCode's `instructions` configuration or merged into
+a project's `AGENTS.md`. The MCP connection is configured separately; see
+[`CONNECT.md`](CONNECT.md).
+
+gnt-brain exposes `check_action`, `search_rules`, `get_rule`, `list_skill_packs`, and
+`get_skill_pack`.
+
+## Before taking an action
+
+Before sending a message, moving money, deleting data, or taking another action that is hard to
+undo, call `check_action` with a plain-English description of the exact action.
+
+This instruction does not enforce the decision by itself. The client or executor that performs
+the side effect must require an `allowed` verdict for the same recipient, amount, target, and
+scope. Run a new check if any of those details change.
+
+- If the verdict is `allowed`, proceed with the action.
+- If the verdict is `blocked`, stop. Explain why and cite the returned rule.
+- If the verdict is `needs_human`, stop and ask a human to approve the action.
+
+A missing, failed, expired, or unclear verdict is not permission to continue.
+
+## Before answering a policy question
+
+Use `search_rules` to find the organization's approved rules. Use `get_rule` when you need the
+full text of one rule. Draft, in-review, rejected, and deprecated rules are not policy.
+
+Use `list_skill_packs` and `get_skill_pack` for compiled company context instead of guessing.
+
+## When a human is needed
+
+Do not retry with a softer description, route around the check, or choose a branch for the human.
+Show the proposed action and gnt-brain's reason, then wait for the decision.

--- a/integrations/opencode/TOOLS.md
+++ b/integrations/opencode/TOOLS.md
@@ -10,11 +10,16 @@ gnt-brain exposes `check_action`, `search_rules`, `get_rule`, `list_skill_packs`
 ## Before taking an action
 
 Before sending a message, moving money, deleting data, or taking another action that is hard to
-undo, call `check_action` with a plain-English description of the exact action.
+undo, build one canonical snapshot containing every input that can change the side effect. Include
+the operation, resource identifiers, destination, content or payload, options, permissions, and
+any other relevant field in a deterministic order. Send that complete snapshot in the
+`check_action` description; free-form context is not a substitute for an omitted field.
 
-This instruction does not enforce the decision by itself. The client or executor that performs
-the side effect must require an `allowed` verdict for the same recipient, amount, target, and
-scope. Run a new check if any of those details change.
+This instruction does not enforce the decision by itself. The client or executor must retain the
+checked snapshot with the verdict, recreate the snapshot from the actual operation immediately
+before execution, and require both an `allowed` verdict and an exact match. Run `check_action`
+again whenever any side-effect-relevant field changes; never reuse approval for a different
+snapshot.
 
 - If the verdict is `allowed`, proceed with the action.
 - If the verdict is `blocked`, stop. Explain why and cite the returned rule.


### PR DESCRIPTION
## What & why

Closes #202.

Add an OpenCode-specific gnt-brain integration guide that:

- configures the remote MCP endpoint with API-key authentication and environment interpolation
- loads the check-action policy through OpenCode's `instructions` support or `AGENTS.md`
- documents safe verification and troubleshooting without using real side effects

The companion `TOOLS.md` follows the existing Cline, Goose, and Zed policy wording so OpenCode handles `allowed`, `blocked`, and `needs_human` verdicts consistently.

The configuration shape and commands were checked against OpenCode's current MCP, config, and rules documentation on 2026-08-29.

## Test plan

- Parsed both fenced JSON examples with Node's `JSON.parse`.
- Confirmed the linked OpenCode MCP and rules documentation return HTTP 200.
- Ran `git diff --check origin/main...HEAD`.
- Did not run the application test suites because this PR adds standalone Markdown integration docs only.
- Did not perform a live authenticated gnt-brain connection because that requires a real MCP key; the guide provides non-production verification steps for reviewers.

## Before you open this

- [x] Commits are signed off (`git commit -s`) — see `CONTRIBUTING.md`'s DCO section.
- [x] Functionally correct: the configuration examples parse and match the current upstream OpenCode documentation.
- [x] No dead code — this change contains documentation only.
- [x] Non-trivial logic has a test — not applicable; no executable logic changed.
- [x] Multi-tenant isolation — not applicable; no server or data path changed.
- [x] Matches this repo's existing integration guide and action-policy patterns.
- [x] Extraction evaluation — not applicable; `apps/cli/src/prebrain/extraction/` is unchanged.

AI assistance: OpenAI Codex helped draft the documentation; I reviewed the final diff and verified every configuration field and command against the cited upstream documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for connecting OpenCode to the gnt-brain MCP server.
  * Documented API key configuration for Bash, PowerShell, and Command Prompt.
  * Added guidance for installing and using OpenCode tool-usage instructions.
  * Included verification steps, troubleshooting guidance, and approval-handling requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->