### PR TITLE
fix: resolve JavaScript audit advisories

### DIFF
--- a/apps/store/bun.lock
+++ b/apps/store/bun.lock
@@ -22,7 +22,7 @@
   "overrides": {
     "@hono/node-server": "^2.0.5",
     "brace-expansion": "^5.0.9",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.6",
     "minimatch": "^10.2.5",
   },
   "packages": {

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -29,7 +29,7 @@
   },
   "overrides": {
     "@hono/node-server": "^2.0.5",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.6",
     "brace-expansion": "^5.0.9",
     "minimatch": "^10.2.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,8 @@ overrides:
   lodash@>=4.0.0 <=4.17.23: ^4.17.24
   postcss@<8.5.23: ^8.5.23
   sharp@<0.35.0: ^0.35.3
-  fast-uri@<=3.1.3: ^3.1.4
+  fast-uri@<3.1.6: ^3.1.6
+  qs@<6.16.0: ^6.16.0
   valibot@<=1.4.1: ^1.4.2
   hono@<4.12.34: ^4.12.34
   js-yaml@^3.13.1: '>=3.15.1 <4'
@@ -3005,6 +3006,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3131,8 +3133,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4329,8 +4331,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -7465,7 +7467,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7511,7 +7513,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -8261,7 +8263,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@7.2.0)
       send: 1.2.1(supports-color@7.2.0)
@@ -8292,7 +8294,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastq@1.20.1:
     dependencies:
@@ -9742,7 +9744,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,8 @@ overrides:
   # above.
   postcss@<8.5.23: ^8.5.23
   sharp@<0.35.0: ^0.35.3
-  fast-uri@<=3.1.3: ^3.1.4
+  fast-uri@<3.1.6: ^3.1.6
+  qs@<6.16.0: ^6.16.0
   valibot@<=1.4.1: ^1.4.2
   # ReDoS in Hono's CORS middleware via Access-Control-Request-Headers.
   # Pulled in transitively via @modelcontextprotocol/sdk (apps/cli's MCP


### PR DESCRIPTION
Updates the repository-wide package overrides and lockfiles to resolve the current fast-uri and qs audit findings.\n\nValidation: pnpm audit passes with no known vulnerabilities. Bun is not installed in this environment, so the store audit is left to CI.