### PR TITLE
docs: correct issue template area labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ assignees: ""
 
 ## Which part of gnt
 
-- [ ] apps/docs (marketing site / docs)
+- [ ] apps/docs (documentation site)
 - [ ] apps/api (rules pipeline, GitHub webhook, MCP server, connectors)
 - [ ] apps/cli (`gnt` command)
 - [ ] apps/store (rules storage, approval gate)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,7 @@ actionable.
 
 ## Which part of gnt this touches
 
-- [ ] apps/docs (marketing site / docs)
+- [ ] apps/docs (documentation site)
 - [ ] apps/api (rules pipeline, GitHub webhook, MCP server, connectors)
 - [ ] apps/cli (`gnt` command)
 - [ ] apps/store (rules storage, approval gate)


### PR DESCRIPTION
Fixes #161. The issue templates now identify pps/docs as the documentation site instead of referring to the absent pps/web directory.